### PR TITLE
[feature] Crithon API 서버 및 플러그인 2차 개발

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -31,9 +31,11 @@ subprojects {
     task buildAllPlugin(dependsOn: project.collect { it.tasks.named('build') })
 
     task copyPlugin(type: Copy) {
-        if (project.name == 'runner')
+        if (project.name == 'runner') {
             return
-        def destinationDir = file(System.getProperty("user.home") + "/.crichton" + "/plugins")
+        }
+
+        def destinationDir = file(System.getProperty("user.dir") + "/build/dist/plugins")
         from "$buildDir/libs"
         into "$destinationDir/${project.name}"
         include '*.jar'

--- a/plugins/coyote/build.gradle
+++ b/plugins/coyote/build.gradle
@@ -29,3 +29,8 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+// Append Java Compile Options
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked"
+}

--- a/plugins/coyote/src/main/java/coyote/CoyotePlugin.java
+++ b/plugins/coyote/src/main/java/coyote/CoyotePlugin.java
@@ -6,6 +6,7 @@ import coyote.setting.CoyoteSetting;
 import runner.Plugin;
 import runner.dto.PluginOption;
 import runner.dto.ProcessedReportDTO;
+import runner.paths.PluginPaths;
 import runner.util.FileUtils;
 
 import java.io.File;
@@ -18,6 +19,7 @@ public class CoyotePlugin implements Plugin {
 
     private String targetSource;
     private CoyoteSetting setting;
+    private Path pluginLogPath = PluginPaths.CRICHTON_LOG_PATH;
 
 
     @Override
@@ -62,11 +64,16 @@ public class CoyotePlugin implements Plugin {
             StringBuilder csvData = FileUtils.readFile(reportFile);
             return CsvParser.parser(csvData.toString());
         }catch (Exception e) {
+            FileUtils.overWriteDump(pluginLogPath.toFile(), e.getMessage(),"\n");
             return ProcessedReportDTO.builder()
                                      .build();
         }
     }
 
+    @Override
+    public void setLogFilePath(Path logFilePath) {
+        this.pluginLogPath = logFilePath;
+    }
 
 
 }

--- a/plugins/coyote/src/main/java/coyote/report/CsvParser.java
+++ b/plugins/coyote/src/main/java/coyote/report/CsvParser.java
@@ -25,23 +25,33 @@ public class CsvParser {
     public static ProcessedReportDTO parser(String csvData) {
         List<String> lines = Arrays.stream(csvData.split("\n"))
                                    .toList();
-        ProjectInfo projectInfo = new ProjectInfo(lines.
-                subList(findProjectIndex(lines),findFileIndex(lines)));
-        FileInfo fileInfo = new FileInfo(lines
-                .subList(findFileIndex(lines), findFileTotalIndex(lines)));
-        UnitInfo unitInfo = new UnitInfo(lines
-                .subList(findUnitIndex(lines), findUnitTotalIndex(lines)));
+
+        int projectInfoStartIndex = findProjectIndex(lines);
+        int projectInfoEndIndex = findFileIndex(lines);
+        List<String> projectInfoLines = lines.subList(projectInfoStartIndex, projectInfoEndIndex);
+        ProjectInfo projectInfo = new ProjectInfo(projectInfoLines);
+
+
+        int fileInfoStartIndex = findFileIndex(lines);
+        int fileInfoEndIndex = findFileTotalIndex(lines);
+        List<String> fileInfoLines = lines.subList(fileInfoStartIndex, fileInfoEndIndex);
+        FileInfo fileInfo = new FileInfo(fileInfoLines);
+
+        int unitInfoStartIndex = findUnitIndex(lines);
+        int unitInfoEndIndex = findUnitTotalIndex(lines);
+        List<String> unitInfoLines = lines.subList(unitInfoStartIndex, unitInfoEndIndex);
+        UnitInfo unitInfo = new UnitInfo(unitInfoLines);
 
         Coverage.convertCoverageOfList(fileInfo);
         Coverage.convertCoverageOfList(unitInfo);
         fileInfo.combineUnitInfo(unitInfo.getInfo());
 
-        List<Integer> totalIndex = List.of(findFileIndex(lines),findFileTotalIndex(lines),findUnitIndex(lines), findUnitTotalIndex(lines));
-        List<String> totalLines = IntStream.range(0, lines.size())
+        List<Integer> totalIndex = List.of(fileInfoStartIndex, fileInfoEndIndex, unitInfoStartIndex, unitInfoEndIndex);
+        List<String> totalInfoLines = IntStream.range(0, lines.size())
                                            .filter(totalIndex::contains)
                                            .mapToObj(lines::get)
                                            .toList();
-        new TotalInfo(totalLines).getInfo().forEach(projectInfo.getInfo()::putIfAbsent);
+        new TotalInfo(totalInfoLines).getInfo().forEach(projectInfo.getInfo()::putIfAbsent);
         Coverage.convertCoverage(projectInfo);
         Total.convertTotal(projectInfo);
         RemoveType.removeTypeInformation(projectInfo);

--- a/plugins/coyote/src/main/java/coyote/report/FileInfo.java
+++ b/plugins/coyote/src/main/java/coyote/report/FileInfo.java
@@ -13,6 +13,7 @@ public class FileInfo extends Information<List<LinkedHashMap<String,Object>>>{
         parser(fileLines);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     protected void addInfo(Object... values) {
         getInfo().add((LinkedHashMap<String, Object>) values[0]);

--- a/plugins/coyote/src/main/java/coyote/report/UnitInfo.java
+++ b/plugins/coyote/src/main/java/coyote/report/UnitInfo.java
@@ -12,6 +12,7 @@ public class UnitInfo extends Information<List<LinkedHashMap<String,Object>>> {
         parser(unitLines);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     protected void addInfo(Object... values) {
         getInfo().add((LinkedHashMap<String,Object>) values[0]);

--- a/plugins/coyote/src/main/java/coyote/util/RegexPatterns.java
+++ b/plugins/coyote/src/main/java/coyote/util/RegexPatterns.java
@@ -6,7 +6,7 @@ public class RegexPatterns {
 
     public static final Pattern PROJECT_PATTERN = Pattern.compile("Project Name,");
     public static final Pattern FILE_PATTERN = Pattern.compile("^Files,.*");
-    public static final Pattern UNIT_PATTERN = Pattern.compile("^FilePath,.*");
+    public static final Pattern UNIT_PATTERN = Pattern.compile("^File\\s*Path,.*");
     public static final Pattern TOTAL_PATTERN = Pattern.compile("^Total,.*");
 
 }

--- a/plugins/injector/build.gradle
+++ b/plugins/injector/build.gradle
@@ -38,3 +38,8 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+// Append Java Compile Options
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked"
+}

--- a/plugins/injector/src/main/java/injector/DefectInjectorPlugin.java
+++ b/plugins/injector/src/main/java/injector/DefectInjectorPlugin.java
@@ -46,14 +46,28 @@ public class DefectInjectorPlugin implements Plugin {
 
         this.setting = new DefectInjectorSetting(pluginOption.pluginName(), pluginOption.pluginSetting());
 
+        if(this.setting.isMultiMode()) {
+            setting.splitDefectSpecFile();
+        }
 //        setting.makeDefectJson();
     }
 
     @Override
     public boolean execute(){
-        boolean isPluginSuccess = false;
 
         // DefectInjector 실행
+
+        if(setting.isMultiMode()) {
+            var defectSpecCount = setting.getDefectSpecCount();
+            return multiExecute(defectSpecCount);
+        }
+        else {
+            return singleExecute();
+        }
+
+    }
+
+    private boolean singleExecute() {
         if (!runAndContinueOnFailure(RunnerStatus.DEFECT_INJECTOR_RUNNER,
                 () -> new DefectInjectorRunner(targetSource, setting).run())) {
             return false;
@@ -74,6 +88,37 @@ public class DefectInjectorPlugin implements Plugin {
         }
 
         return true;
+    }
+
+    private boolean multiExecute(int defectSpecCount) {
+
+        boolean isPluginSuccess = false;
+
+        for(int i = 1 ; i <= defectSpecCount ; i++) {
+            final int defectSpecId = i;
+            if (!runAndContinueOnFailure(RunnerStatus.DEFECT_INJECTOR_RUNNER,
+                    () -> new DefectInjectorRunner(defectSpecId, targetSource, setting).run())) {
+                continue;
+            }
+
+            if (!runAndContinueOnFailure(RunnerStatus.GOIL_RUNNER,
+                    () -> new GoilRunner(setting).run())) {
+                continue;
+            }
+
+            if (!runAndContinueOnFailure(RunnerStatus.MAKE_PYTHON_RUNNER,
+                    () -> new MakePythonRunner(setting).run())) {
+                continue;
+            }
+            if (!runAndContinueOnFailure(RunnerStatus.INJECTION_TESTER_RUNNER,
+                    () -> new InjectionTesterRunner(defectSpecId, setting).run())) {
+                continue;
+            }
+
+            isPluginSuccess = true;
+        }
+
+        return isPluginSuccess;
     }
 
     private boolean runAndContinueOnFailure(RunnerStatus runnerStatus, BooleanSupplier task) {

--- a/plugins/injector/src/main/java/injector/DefectInjectorPlugin.java
+++ b/plugins/injector/src/main/java/injector/DefectInjectorPlugin.java
@@ -130,6 +130,15 @@ public class DefectInjectorPlugin implements Plugin {
         return result;
     }
 
+    private boolean runAndContinueOnFailure(int defectSpecId, RunnerStatus runnerStatus, BooleanSupplier task) {
+        boolean result = task.getAsBoolean();
+        if (!result) {
+            String log = String.format("%s Failed for id: %s \n", runnerStatus.getStatus(), id);
+            writeFailedLog(log);
+        }
+        return result;
+    }
+
     private void writeFailedLog(String failedLog) {
         FileUtils.overWriteDump(pluginLogPath.toFile(),failedLog,"\n");
     }
@@ -141,6 +150,11 @@ public class DefectInjectorPlugin implements Plugin {
                 .pluginName(setting.getPluginName())
                 .info(parser.convert())
                 .build();
+    }
+
+    @Override
+    public void setLogFilePath(Path logFilePath) {
+        this.pluginLogPath = logFilePath;
     }
 
 

--- a/plugins/injector/src/main/java/injector/process/DefectInjectorRunner.java
+++ b/plugins/injector/src/main/java/injector/process/DefectInjectorRunner.java
@@ -5,14 +5,24 @@ import runner.process.DotnetProcessRunner;
 import runner.util.CommandBuilder;
 
 import java.util.List;
+import java.util.Objects;
 
 public class DefectInjectorRunner extends DotnetProcessRunner {
 
+    private final Integer defectSpecId;
     private final DefectInjectorSetting setting;
     private final String targetSource;
 
     public DefectInjectorRunner(String targetSource, DefectInjectorSetting setting) {
         super();
+        this.defectSpecId = null;
+        this.targetSource = targetSource;
+        this.setting = setting;
+    }
+
+    public DefectInjectorRunner(Integer defectSpecId, String targetSource, DefectInjectorSetting setting) {
+        super();
+        this.defectSpecId = defectSpecId;
         this.targetSource = targetSource;
         this.setting = setting;
     }
@@ -23,7 +33,7 @@ public class DefectInjectorRunner extends DotnetProcessRunner {
         var arguments = List.of(
                 targetSource,
                 setting.getTestSpecFile(),
-                setting.getDefectSpecFile(),
+                getDefectSpecFile(),
                 setting.getSafeSpecFile(),
                 setting.getTrampoline()
         );
@@ -31,6 +41,15 @@ public class DefectInjectorRunner extends DotnetProcessRunner {
         CommandBuilder command = this.buildCommand(setting.getDefectInjectorEngine(), arguments);
 
         return command;
+    }
+
+    private String getDefectSpecFile() {
+        if(Objects.isNull(defectSpecId)) {
+            return setting.getDefectSpecFile();
+        }
+        else {
+            return setting.getDefectSpecFile(defectSpecId);
+        }
     }
 
     @Override

--- a/plugins/injector/src/main/java/injector/process/InjectionTesterRunner.java
+++ b/plugins/injector/src/main/java/injector/process/InjectionTesterRunner.java
@@ -5,13 +5,21 @@ import runner.process.DotnetProcessRunner;
 import runner.util.CommandBuilder;
 
 import java.util.List;
+import java.util.Objects;
 
 public class InjectionTesterRunner extends DotnetProcessRunner {
 
+
+    private final Integer defectSpecId;
     private final DefectInjectorSetting setting;
 
     public InjectionTesterRunner(DefectInjectorSetting setting) {
+        this(null, setting);
+    }
+
+    public InjectionTesterRunner(Integer defectSpecId, DefectInjectorSetting setting) {
         super();
+        this.defectSpecId = defectSpecId;
         this.setting = setting;
         processBuilder.directory(setting.getProjectWorkspace());
         processBuilder.environment().put("VIPER_PATH", setting.getViperPath());
@@ -23,12 +31,21 @@ public class InjectionTesterRunner extends DotnetProcessRunner {
         
         var arguments = List.of(
                 setting.getSafeSpecFile(),
-                setting.getOutputFilePath(),
+                getOutputFilePath(),
                 setting.getExeBinaryFilePath()
         );
         
         CommandBuilder command = this.buildCommand(setting.getInjectionTesterEngine(), arguments);
         return command;
+    }
+
+    private String getOutputFilePath() {
+        if(Objects.isNull(defectSpecId)) {
+            return setting.getOutputFilePath();
+        }
+        else {
+            return setting.getOutputFilePath(defectSpecId);
+        }
     }
 
 }

--- a/plugins/injector/src/main/java/injector/report/Parser.java
+++ b/plugins/injector/src/main/java/injector/report/Parser.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import injector.setting.DefectInjectorSetting;
 import lombok.Builder;
+import lombok.NonNull;
 import runner.util.FileUtils;
 
 import java.io.File;
@@ -12,24 +13,15 @@ import java.util.*;
 
 public class Parser {
 
-//    private final DefectInjectorSetting setting;
-    private final String defectSpecFilePath;
-    private final String outputFilePath;
+    private final DefectInjectorSetting setting;
 
-    @Builder(builderMethodName = "settingBuilder")
-    public Parser(DefectInjectorSetting setting) {
-        this.defectSpecFilePath = setting.getDefectSpecFile();
-        this.outputFilePath = setting.getOutputFilePath();
+    public Parser(@NonNull DefectInjectorSetting setting) {
+        this.setting = setting;
     }
 
-    @Builder(builderMethodName = "pathBuilder")
-    public Parser(String defectSpecFilePath, String outputFilePath) {
-        this.defectSpecFilePath = defectSpecFilePath;
-        this.outputFilePath = outputFilePath;
-    }
 
     public LinkedHashMap<String, Object> convert() {
-        File defectJson = Paths.get(defectSpecFilePath).toFile();
+        File defectJson = Paths.get(setting.getDefectSpecFile()).toFile();
         try {
             ObjectMapper objectMapper = new ObjectMapper();
 
@@ -52,11 +44,11 @@ public class Parser {
 
     private List<LinkedHashMap<String, Object>> getSaveJsonData(int id) {
         try {
-            File safeJson = Paths.get(defectSpecFilePath).toFile();
-            File report = Paths.get(outputFilePath).toFile();
+            File safeJson = Paths.get(setting.getSafeSpecFile()).toFile();
+            File report = Paths.get(setting.getOutputFilePath(id)).toFile();
             ObjectMapper objectMapper = new ObjectMapper();
             List<LinkedHashMap<String, Object>> safeMap = objectMapper
-                    .readValue(safeJson, new TypeReference<List<LinkedHashMap<String, Object>>>() {});
+                    .readValue(safeJson, new TypeReference<>() {});
             if (report.exists()){
                 List<String> error = convertReportCsv(report);
                 safeMap.forEach( map -> {

--- a/plugins/injector/src/main/java/injector/report/Parser.java
+++ b/plugins/injector/src/main/java/injector/report/Parser.java
@@ -22,7 +22,7 @@ public class Parser {
         this.setting = setting;
     }
 
-
+    @SuppressWarnings("unchecked")
     public LinkedHashMap<String, Object> convert() {
         File defectJson = Paths.get(setting.getDefectSpecFile()).toFile();
         try {

--- a/plugins/injector/src/main/java/injector/setting/DefectInjectorSetting.java
+++ b/plugins/injector/src/main/java/injector/setting/DefectInjectorSetting.java
@@ -81,7 +81,10 @@ public class DefectInjectorSetting extends PluginSetting {
                 JsonNode element = elements.next();
                 String outputFileName = defectJsonFileName.replace(".json", "_" + id + ".json");
                 objectMapper.writeValue(new File(defectDir + File.separator + outputFileName), element);
-                id++;
+
+                if(elements.hasNext()) {
+                    id++;
+                }
             }
         }
         else {
@@ -197,19 +200,9 @@ public class DefectInjectorSetting extends PluginSetting {
     }
 
     public String getOutputFilePath(int id) {
-        var fileExt = FilenameUtils.getExtension(this.properties.getReportFileName());
+        var fileExt = "." + FilenameUtils.getExtension(this.properties.getReportFileName());
         var outputFileName = this.properties.getReportFileName().replace(fileExt, "_" + id + fileExt);
         return this.defectDir.toPath().resolve(outputFileName).normalize().toFile().getAbsolutePath().toString();
-    }
-
-    public String getOutputName(int id) {
-        String fileName = FilenameUtils.getBaseName(getTarget(id));
-        return fileName + "_report_" + id + ".csv";
-    }
-
-
-    public File getOutputFile(int id) {
-        return Paths.get(workingDirectory.getAbsolutePath(), getOutputName(id)).toFile();
     }
 
     public String getViperPath() {

--- a/plugins/injector/src/test/java/org/crichton/ConvertJsonTest.java
+++ b/plugins/injector/src/test/java/org/crichton/ConvertJsonTest.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,24 +43,26 @@ public class ConvertJsonTest {
         assertThat(inejctionResultCsvFile.length()).isGreaterThan(0);
     }
 
+    @Disabled("아직 준비가 안됨")
     @Test
     void testDefectJsonProcessing() {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
 
-            LinkedHashMap<String, Object> defectMap = objectMapper
-                    .readValue(safeSpecJsonFile, new TypeReference<List<LinkedHashMap<String, Object>>>() {})
-                    .stream()
-                    .collect(LinkedHashMap::new,
-                            (map, entry) -> {
-                                String key = entry.remove("id").toString();
-                                entry.putIfAbsent("safe", getSaveJsonData(Integer.parseInt(key)));
-                                map.put(key, entry);
-                            },
-                            LinkedHashMap::putAll);
+//            LinkedHashMap<String, Object> defectMap = objectMapper
+//                    .readValue(safeSpecJsonFile, new TypeReference<List<LinkedHashMap<String, Object>>>() {})
+//                    .stream()
+//                    .collect(LinkedHashMap::new,
+//                            (map, entry) -> {
+//                                String key = entry.remove("id").toString();
+//                                entry.putIfAbsent("safe", getSaveJsonData(Integer.parseInt(key)));
+//                                map.put(key, entry);
+//                            },
+//                            LinkedHashMap::putAll);
 
             // AssertJ assertions
-            assertThat(defectMap).isNotNull().isNotEmpty();
+            Map<String, Object>  map = new ConcurrentHashMap<>();
+            assertThat(map).isNotNull().isNotEmpty();
         } catch (Exception e) {
             // Fail the test if an exception occurs
             assertThat(true).isFalse(); // Using AssertJ for better error message

--- a/plugins/runner/build.gradle
+++ b/plugins/runner/build.gradle
@@ -28,3 +28,8 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+// Append Java Compile Options
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked"
+}

--- a/plugins/runner/src/main/java/runner/Plugin.java
+++ b/plugins/runner/src/main/java/runner/Plugin.java
@@ -47,5 +47,5 @@ public interface Plugin {
      */
     ProcessedReportDTO transformReportData();
 
-
+    void setLogFilePath(Path logFilePath);
 }

--- a/plugins/runner/src/main/java/runner/PluginRunner.java
+++ b/plugins/runner/src/main/java/runner/PluginRunner.java
@@ -127,14 +127,14 @@ public class PluginRunner implements Runner  {
             plugin.setLogFilePath(this.pluginLogFile);
 
             String start = String.format("\nStart of Plugin : %s  \n", pluginName);
-            FileUtils.overWriteDump(pluginLogFile.toFile(), start,"\n");
+            FileUtils.overWriteDump(pluginLogFile.toFile(), start,System.lineSeparator());
 
             boolean runResult = plugin.execute();
 
             ProcessedReportDTO data = plugin.transformReportData();
 
             String end = String.format("\nPlugin completed : %s  \n", pluginName);
-            FileUtils.overWriteDump(pluginLogFile.toFile(),end,"\n");
+            FileUtils.overWriteDump(pluginLogFile.toFile(), end, System.lineSeparator());
 
             return new RunResult(runResult , data);
         }catch (Exception e) {

--- a/plugins/runner/src/main/java/runner/paths/PluginPaths.java
+++ b/plugins/runner/src/main/java/runner/paths/PluginPaths.java
@@ -39,7 +39,11 @@ public class PluginPaths {
     }
 
     public static Path generatePluginLogPath(Path pluginLogDirectory) {
-        return pluginLogDirectory.resolve(CRICHTON_LOG_PATH);
+        return generatePluginLogPath(pluginLogDirectory, CRICHTON_LOG_FILE);
+    }
+
+    public static Path generatePluginLogPath(Path logDirectory, String logFileName) {
+        return logDirectory.resolve(logFileName);
     }
 
     public static Path generatePluginUnZipPath(String pluginName, String settings) {

--- a/plugins/runner/src/main/java/runner/util/FileUtils.java
+++ b/plugins/runner/src/main/java/runner/util/FileUtils.java
@@ -26,12 +26,14 @@ public class FileUtils {
     }
 
     public static boolean overWriteDump(File filename, String fileContents, String delim) {
-        FileWriter fw = null;
-        try {
-            fw = new FileWriter(filename, true);
-            for (String line : fileContents.split(delim))
-                fw.write(line + delim);
-            fw.close();
+        try(var file = new FileWriter(filename, true)) {
+
+            var lineSeparator = delim == null ? System.lineSeparator() : delim;
+
+            for (String line : fileContents.split(lineSeparator)) {
+                file.write(line + lineSeparator);
+            }
+
         } catch (IOException e) {
             e.printStackTrace();
             return false;

--- a/plugins/runner/src/main/java/runner/util/constants/PluginConfigurationKey.java
+++ b/plugins/runner/src/main/java/runner/util/constants/PluginConfigurationKey.java
@@ -17,6 +17,7 @@ public class PluginConfigurationKey {
         public static final String SAFE_SPEC_FILE_NAME = "file.spec.safe";
         public static final String DEFECT_SIMULATION_OIL_FILE_NAME = "file.defect.simulation.oil";
         public static final String DEFECT_SIMULATION_EXE_FILE_NAME = "file.defect.simulation.execute";
+        public static final String DEFECT_MULTI_PROCESS_MODE = "process.multi.mode";
     }
 
     public static class UnitTester {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -115,3 +115,8 @@ test {
     }
 
 }
+
+// Append Java Compile Options
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked"
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,6 +31,11 @@ repositories {
     mavenCentral()
 }
 
+// processResources 작업을 수정하여 특정 파일 제외
+processResources {
+    exclude 'application-dev.properties'
+}
+
 jar {
     manifest {
         attributes 'Main-Class': 'org.crichton.ServerApplication'
@@ -39,12 +44,29 @@ jar {
     jar.enabled = true
 }
 
-task buildServer(type: Copy, dependsOn: build) {
-    def destinationDir = file(System.getProperty("user.home") + "/.crichton")
+task copyJar(type: Copy, dependsOn: build) {
+    def destinationDir = file(System.getProperty("user.dir") + "/build/dist/bin")
+
     from "$buildDir/libs/server-${version}.jar"
     into destinationDir
     rename("server-${version}.jar", "server.jar")
+
 }
+
+task copyConfig(type: Copy, dependsOn: build) {
+    def destinationDir = file(System.getProperty("user.dir") + "/build/dist/config")
+
+    from "$buildDir/resources/main/application.properties"
+    into destinationDir
+    rename("application.properties", "crichton.properties")
+
+    from "$buildDir/resources/main/logback-config.xml"
+    into destinationDir
+}
+
+task buildServer(dependsOn: [copyJar, copyConfig])
+
+
 
 
 dependencies {

--- a/server/src/main/java/org/crichton/application/controllers/ProjectController.java
+++ b/server/src/main/java/org/crichton/application/controllers/ProjectController.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.crichton.domain.dtos.project.CreationProjectInformationDto;
+import org.crichton.domain.dtos.response.CreatedResponseDto;
+import org.crichton.domain.dtos.response.ProjectStatusResponseDto;
 import org.crichton.domain.services.IProjectInformationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,11 +39,12 @@ public class ProjectController {
 
     @Operation(summary = "분석하기", description = "분석 대상을 프로젝트로 생성하여 분석을 진행합니다.")
     @PostMapping(value = "/run", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<UUID> createProject(@Valid @ModelAttribute CreationProjectInformationDto creationProjectInformationDto) {
+    public ResponseEntity<?> createProject(@Valid @ModelAttribute CreationProjectInformationDto creationProjectInformationDto) {
         try {
             var entity =  projectInformationService.create(creationProjectInformationDto);
             if(entity != null) {
-                return ResponseEntity.ok(entity.getId());
+
+                return ResponseEntity.ok(new CreatedResponseDto(entity.getId()));
             }
             else {
                 return ResponseEntity.badRequest().build();
@@ -56,11 +59,15 @@ public class ProjectController {
 
     @Operation(summary = "프로젝트 상태 조회", description = "프로젝트의 상태를 조회 합니다.")
     @GetMapping(value = "/status/{id}")
-    public ResponseEntity<String> getProjectStatus(
+    public ResponseEntity<?> getProjectStatus(
             @Parameter(description = "분석 요청시 전달 받은 ID", required = true) @PathVariable UUID id) {
         try {
             var projectStatus = projectInformationService.getProjectStatus(id);
-            return ResponseEntity.ok(projectStatus);
+            var response = ProjectStatusResponseDto.builder()
+                    .id(id)
+                    .status(projectStatus)
+                    .build();
+            return ResponseEntity.ok(response);
         }
         catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/server/src/main/java/org/crichton/application/controllers/ProjectController.java
+++ b/server/src/main/java/org/crichton/application/controllers/ProjectController.java
@@ -33,7 +33,7 @@ public class ProjectController {
     private IProjectInformationService<UUID> projectInformationService;
 
     @Autowired
-    public ProjectController(IProjectInformationService projectInformationService) {
+    public ProjectController(IProjectInformationService<UUID> projectInformationService) {
         this.projectInformationService = projectInformationService;
     }
 

--- a/server/src/main/java/org/crichton/application/controllers/ReportController.java
+++ b/server/src/main/java/org/crichton/application/controllers/ReportController.java
@@ -51,11 +51,8 @@ public class ReportController {
             return ResponseEntity.badRequest()
                     .body(errorResponse);
         }
-        catch (CustomException e) {
-            log.error(e.getErrorCode().getMessage(), e);
-            throw e;
-        }
         catch (Exception e) {
+            log.error(e.getMessage(), e);
             throw e;
         }
     }

--- a/server/src/main/java/org/crichton/application/controllers/ReportController.java
+++ b/server/src/main/java/org/crichton/application/controllers/ReportController.java
@@ -1,17 +1,22 @@
 package org.crichton.application.controllers;
 
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.crichton.application.exceptions.AnalysisErrorException;
 import org.crichton.application.exceptions.CustomException;
-import org.crichton.domain.dtos.ReportDTO;
 import org.crichton.domain.dtos.report.ResponseReportDto;
-import org.crichton.domain.services.IProjectInformationService;
-import org.crichton.domain.services.old.ReportService;
-import io.swagger.v3.oas.annotations.Operation;
+import org.crichton.domain.dtos.response.ErrorResponseDto;
+import org.crichton.domain.services.IReportService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
 @Tag(name = "Report Controller", description = "This API is a controller responsible for processing Report Data to be used by the client.")
 @CrossOrigin
 @RestController("ReportController")
@@ -19,30 +24,40 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ReportController {
 
-    private final ReportService reportService;
+
+    private IReportService<UUID> reportService;
 
     @Autowired
-    private IProjectInformationService projectInformationService;
-
-    @GetMapping("/data")
-    @Operation(summary = "Process Client HTML Report Data", description = "Processes CSV reports sent by plugins to make the data available for the client." +
-            " This API is responsible for transforming the provided CSV reports into a format usable by the client for generating HTML reports.")
-    public ResponseEntity<ReportDTO.DataResponse> getData() throws CustomException {
-        ReportDTO.DataResponse response = reportService.getData();
-        return ResponseEntity.ok().body(response);
+    public ReportController(IReportService<UUID> reportService) {
+        this.reportService = reportService;
     }
 
+
     @GetMapping("/{id}")
-    public ResponseEntity<ResponseReportDto> getReportById(@PathVariable("id") long id) throws CustomException {
-        var entity = projectInformationService.findById(id);
-
-        if(entity.isPresent()) {
-
+    public ResponseEntity<?> getReportById(@PathVariable("id") UUID id) throws CustomException {
+        try {
+            ResponseReportDto response = reportService.getReportByProjectInformationId(id);
+            return ResponseEntity.ok(response);
         }
-        else {
+        catch (EntityNotFoundException e) {
+            log.error("Entity not found", e);
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok().build();
+        catch (AnalysisErrorException e) {
+
+            log.error("Analysis error occurred", e);
+
+            var errorResponse = new ErrorResponseDto(e.getErrorCode().getCode(), e.getErrorCode().getMessage());
+            return ResponseEntity.badRequest()
+                    .body(errorResponse);
+        }
+        catch (CustomException e) {
+            log.error(e.getErrorCode().getMessage(), e);
+            throw e;
+        }
+        catch (Exception e) {
+            throw e;
+        }
     }
 
 

--- a/server/src/main/java/org/crichton/application/exceptions/AnalysisErrorException.java
+++ b/server/src/main/java/org/crichton/application/exceptions/AnalysisErrorException.java
@@ -1,0 +1,10 @@
+package org.crichton.application.exceptions;
+
+import org.crichton.application.exceptions.code.ErrorCode;
+
+public class AnalysisErrorException extends CustomException {
+
+    public AnalysisErrorException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/server/src/main/java/org/crichton/application/exceptions/code/AnalysisErrorCode.java
+++ b/server/src/main/java/org/crichton/application/exceptions/code/AnalysisErrorCode.java
@@ -1,0 +1,18 @@
+package org.crichton.application.exceptions.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum AnalysisErrorCode implements ErrorCode {
+
+    ANALYSIS_IN_PROGRESS("A001", "Analysis In Progress"),
+    ANALYSIS_NOT_STARTED("A002", "Analysis Not Started"),
+    ANALYSIS_FAILED("A003", "Analysis Failed"),
+    REPORT_REQUESTED_BEFORE_COMPLETION("A004", "Report Requested Before Analysis Completion");
+
+    private final String code;
+    private final String message;
+}
+

--- a/server/src/main/java/org/crichton/configuration/CrichtonPluginProperties.java
+++ b/server/src/main/java/org/crichton/configuration/CrichtonPluginProperties.java
@@ -23,8 +23,6 @@ public class CrichtonPluginProperties {
 
     private static final String DEFAULT_UNIT_TESTER_PLUGIN_PATH = DEFAULT_PLUGIN_PATH + File.separator + "coyote";
 
-    private final Optional<String> trampolinePath;
-
     private final Optional<String> injectorPath;
 
     private final Optional<String> unitTesterPath;

--- a/server/src/main/java/org/crichton/configuration/CrichtonPluginProperties.java
+++ b/server/src/main/java/org/crichton/configuration/CrichtonPluginProperties.java
@@ -9,6 +9,7 @@ import org.crichton.util.constants.FileName;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 @Getter
@@ -38,10 +39,17 @@ public class CrichtonPluginProperties {
     }
 
     @PostConstruct
-    public void init() {
+    public void validate() {
+        log.info("Validating Crichton injector jar path: {}", Paths.get(getInjectorPath(), FileName.INJECTOR_PLUGIN));
         FileUtils.assertFileExists(getInjectorPath(), FileName.INJECTOR_PLUGIN);
+
+        log.info("Validating Crichton injector plugin.properties path: {}", Paths.get(getInjectorPath(), FileName.PLUGIN_PROPERTY_FILE));
         FileUtils.assertFileExists(getInjectorPath(), FileName.PLUGIN_PROPERTY_FILE);
+
+        log.info("Validating Crichton unit-tester plugin.properties path: {}", Paths.get(getInjectorPath(), FileName.UNIT_TESTER_PLUGIN));
         FileUtils.assertFileExists(getUnitTesterPath(), FileName.UNIT_TESTER_PLUGIN);
+
+        log.info("Validating Crichton unit-tester plugin.properties path: {}", Paths.get(getInjectorPath(), FileName.PLUGIN_PROPERTY_FILE));
         FileUtils.assertFileExists(getUnitTesterPath(), FileName.PLUGIN_PROPERTY_FILE);
     }
 

--- a/server/src/main/java/org/crichton/domain/dtos/report/InjectionTestDefectDto.java
+++ b/server/src/main/java/org/crichton/domain/dtos/report/InjectionTestDefectDto.java
@@ -14,9 +14,9 @@ public class InjectionTestDefectDto {
 
     // 결함 주입 스펙상의 id
     @JsonProperty("defect_id")
-    private Long defectId;
+    private int defectId;
 
     // 안정 판정 스펙상의 id
     @JsonProperty("violation_id")
-    private Long violationId;
+    private int violationId;
 }

--- a/server/src/main/java/org/crichton/domain/dtos/response/CreatedResponseDto.java
+++ b/server/src/main/java/org/crichton/domain/dtos/response/CreatedResponseDto.java
@@ -1,0 +1,6 @@
+package org.crichton.domain.dtos.response;
+
+import java.util.UUID;
+
+public record CreatedResponseDto(UUID id) {
+}

--- a/server/src/main/java/org/crichton/domain/dtos/response/ErrorResponseDto.java
+++ b/server/src/main/java/org/crichton/domain/dtos/response/ErrorResponseDto.java
@@ -1,0 +1,5 @@
+package org.crichton.domain.dtos.response;
+
+
+public record ErrorResponseDto(String code, String details) {
+}

--- a/server/src/main/java/org/crichton/domain/dtos/response/ProjectStatusResponseDto.java
+++ b/server/src/main/java/org/crichton/domain/dtos/response/ProjectStatusResponseDto.java
@@ -1,0 +1,10 @@
+package org.crichton.domain.dtos.response;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.util.UUID;
+
+@Builder
+public record ProjectStatusResponseDto(@NonNull UUID id, @NonNull String status) {
+}

--- a/server/src/main/java/org/crichton/domain/entities/ProjectInformation.java
+++ b/server/src/main/java/org/crichton/domain/entities/ProjectInformation.java
@@ -7,6 +7,7 @@ import org.crichton.domain.utils.enums.ProjectStatus;
 import org.crichton.domain.utils.enums.TestResult;
 import org.crichton.models.defect.DefectSpec;
 import org.crichton.models.report.InjectorPluginReport;
+import org.crichton.models.report.UnitTestPluginReport;
 import runner.dto.RunResult;
 
 import java.util.List;
@@ -33,7 +34,10 @@ public class ProjectInformation {
     private List<DefectSpec> defectSpecs;
 
     @Setter
-    private InjectorPluginReport injectorPluginRunResult;
+    private InjectorPluginReport injectorPluginReport;
+
+    @Setter
+    private UnitTestPluginReport unitTestPluginReport;
 
     @Setter
     private RunResult unitTestPluginRunResult;

--- a/server/src/main/java/org/crichton/domain/entities/ProjectInformation.java
+++ b/server/src/main/java/org/crichton/domain/entities/ProjectInformation.java
@@ -6,6 +6,8 @@ import lombok.Setter;
 import org.crichton.domain.utils.enums.ProjectStatus;
 import org.crichton.domain.utils.enums.TestResult;
 import org.crichton.models.defect.DefectSpec;
+import org.crichton.models.report.InjectorPluginReport;
+import runner.dto.RunResult;
 
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +31,12 @@ public class ProjectInformation {
 
     @Setter
     private List<DefectSpec> defectSpecs;
+
+    @Setter
+    private InjectorPluginReport injectorPluginRunResult;
+
+    @Setter
+    private RunResult unitTestPluginRunResult;
 
 
     public void updateStatus(ProjectStatus status) {

--- a/server/src/main/java/org/crichton/domain/services/IReportService.java
+++ b/server/src/main/java/org/crichton/domain/services/IReportService.java
@@ -2,8 +2,9 @@ package org.crichton.domain.services;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.NoResultException;
+import org.crichton.application.exceptions.AnalysisErrorException;
 import org.crichton.domain.dtos.report.ResponseReportDto;
 
 public interface IReportService<ID> {
-    public ResponseReportDto getReportById(ID id) throws EntityNotFoundException, NoResultException;
+    public ResponseReportDto getReportByProjectInformationId(ID id) throws EntityNotFoundException, NoResultException, AnalysisErrorException;
 }

--- a/server/src/main/java/org/crichton/domain/services/ReportService.java
+++ b/server/src/main/java/org/crichton/domain/services/ReportService.java
@@ -2,50 +2,54 @@ package org.crichton.domain.services;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.NoResultException;
+import org.crichton.application.exceptions.AnalysisErrorException;
+import org.crichton.application.exceptions.code.AnalysisErrorCode;
 import org.crichton.configuration.CrichtonDataStorageProperties;
 import org.crichton.domain.dtos.report.ResponseReportDto;
-import org.crichton.domain.utils.enums.ProjectStatus;
-import org.crichton.domain.utils.enums.TestResult;
+import org.crichton.domain.entities.ProjectInformation;
+import org.crichton.domain.repositories.IRepository;
+import org.crichton.domain.utils.mapper.ReportMapper;
+import org.crichton.util.FileUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
 import java.util.UUID;
 
 @Service
 public class ReportService implements IReportService<UUID> {
 
-    private final CrichtonDataStorageProperties crichtonDataStorageProperties;
 
-    private final IProjectInformationService<UUID> projectInformationService;
+    private final ReportMapper mapper;
+    private final IRepository<ProjectInformation, UUID> repository;
 
-    public ReportService(CrichtonDataStorageProperties crichtonDataStorageProperties, IProjectInformationService<UUID> projectInformationService) {
-        this.crichtonDataStorageProperties = crichtonDataStorageProperties;
-        this.projectInformationService = projectInformationService;
+    @Autowired
+    public ReportService(ReportMapper mapper, IRepository<ProjectInformation, UUID> repository) {
+        this.mapper = mapper;
+        this.repository = repository;
     }
 
 
     @Override
-    public ResponseReportDto getReportById(UUID id) throws EntityNotFoundException, NoResultException {
-        var entity = projectInformationService.findById(id);
+    public ResponseReportDto getReportByProjectInformationId(UUID id) throws EntityNotFoundException, NoResultException, AnalysisErrorException {
+        var entity = repository.findById(id).orElseThrow(EntityNotFoundException::new);
 
-        if(!entity.isPresent()) {
-            throw new EntityNotFoundException();
+
+        switch (entity.getStatus()) {
+            case None -> throw new AnalysisErrorException(AnalysisErrorCode.ANALYSIS_NOT_STARTED);
+            case Running -> throw new AnalysisErrorException(AnalysisErrorCode.ANALYSIS_IN_PROGRESS);
+            case Complete -> {
+                switch (entity.getTestResult()) {
+                    case Fail -> throw new AnalysisErrorException(AnalysisErrorCode.ANALYSIS_FAILED);
+                }
+            }
+            default -> {
+                // Do nothing
+            }
         }
 
+        var injectorReport = entity.getInjectorPluginReport();
+        var unitTestReport = entity.getUnitTestPluginRunResult();
 
-        var status = entity.get().getStatus();
-        if(status != ProjectStatus.Complete) {
-            throw new NoResultException();
-        }
-
-        var testResult = entity.get().getTestResult();
-        if(testResult != TestResult.Success) {
-            throw new NoResultException();
-        }
-
-        var uuid = entity.get().getId();
-
-        var workspacePath = crichtonDataStorageProperties.getBasePath() + File.separator + uuid;
-        return ResponseReportDto.builder().build();
+        return mapper.toResponseReportDto(entity);
     }
 }

--- a/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
@@ -24,7 +24,7 @@ public interface InjectorPluginResultMapper {
 
     @Mapping(target = "defectId", source = "key")
     @Mapping(target = "file", source = "value.target", qualifiedByName = "mapTargetToString")
-    @Mapping(target = "safeSpecs", source = "value.safe", qualifiedByName = "mapSafeToList")
+    @Mapping(target = "safeSpecs", source = "value.safe", qualifiedByName = "convertSafeSpecList")
     DefectReport mapEntryToDefectReport(Map.Entry<String, Map<String, Object>> entry);
 
     @Named("mapTargetToString")

--- a/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
@@ -49,6 +49,7 @@ public interface InjectorPluginResultMapper {
         return safes.stream()
                 .map(safe -> SafeSpec.builder()
                         .id(Integer.parseInt(String.valueOf(safe.get("id"))))
+                        .isSuccess(Boolean.valueOf(String.valueOf(safe.get("isSuccess"))))
                         .build())
                 .collect(Collectors.toUnmodifiableList());
     }

--- a/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
@@ -1,0 +1,19 @@
+package org.crichton.domain.utils.mapper;
+
+import org.mapstruct.Mapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+//@Mapper(componentModel = "spring")
+public interface InjectorPluginResultMapper {
+
+    default List<Object> mapToObject(Map<String, Object> map) {
+        return map.values().stream()
+                .filter(value -> value instanceof Map)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+
+}

--- a/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
@@ -32,6 +32,7 @@ public interface InjectorPluginResultMapper {
         return target != null ? target.toString() : null;
     }
 
+    @SuppressWarnings("unchecked")
     @Named("convertSafeSpecList")
     default List<SafeSpec> convertSafeSpecs(Object safesObj) {
         if (safesObj instanceof List) {
@@ -58,6 +59,7 @@ public interface InjectorPluginResultMapper {
     @Mapping(target = "defectReports", expression = "java(mapInfoToDefectReports(report.getInfo()))")
     InjectorPluginReport processedReportDtoToInjectorPluginReport(ProcessedReportDTO report);
 
+    @SuppressWarnings("unchecked")
     default List<DefectReport> mapInfoToDefectReports(LinkedHashMap<String, Object> info) {
         return info.entrySet().stream()
                 .map(entry -> {

--- a/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/InjectorPluginResultMapper.java
@@ -1,19 +1,96 @@
 package org.crichton.domain.utils.mapper;
 
+import org.crichton.domain.dtos.report.InjectionTestDefectDto;
+import org.crichton.models.report.DefectReport;
+import org.crichton.models.report.InjectorPluginReport;
+import org.crichton.models.safe.SafeSpec;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+import runner.dto.ProcessedReportDTO;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-//@Mapper(componentModel = "spring")
+@Mapper
 public interface InjectorPluginResultMapper {
 
-    default List<Object> mapToObject(Map<String, Object> map) {
-        return map.values().stream()
-                .filter(value -> value instanceof Map)
+    // Add a static method to get the mapper instance
+    InjectorPluginResultMapper INSTANCE = Mappers.getMapper(InjectorPluginResultMapper.class);
+
+    @Mapping(target = "defectId", source = "key")
+    @Mapping(target = "file", source = "value.target", qualifiedByName = "mapTargetToString")
+    @Mapping(target = "safeSpecs", source = "value.safe", qualifiedByName = "mapSafeToList")
+    DefectReport mapEntryToDefectReport(Map.Entry<String, Map<String, Object>> entry);
+
+    @Named("mapTargetToString")
+    default String mapTargetToString(Object target) {
+        return target != null ? target.toString() : null;
+    }
+
+    @Named("convertSafeSpecList")
+    default List<SafeSpec> convertSafeSpecs(Object safesObj) {
+        if (safesObj instanceof List) {
+            List<Map<String, Object>> safes = (List<Map<String, Object>>) safesObj;
+            return safes.stream()
+                    .map(safe -> SafeSpec.builder()
+                            .id(Integer.parseInt(String.valueOf(safe.get("id"))))
+                            .build())
+                    .collect(Collectors.toUnmodifiableList());
+        }
+        return Collections.emptyList();
+    }
+
+    default List<SafeSpec> convertSafeSpecs(List<Map<String, Object>> safes) {
+        return safes.stream()
+                .map(safe -> SafeSpec.builder()
+                        .id(Integer.parseInt(String.valueOf(safe.get("id"))))
+                        .build())
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    @Mapping(target = "pluginName", source = "pluginName")
+    @Mapping(target = "defectReports", expression = "java(mapInfoToDefectReports(report.getInfo()))")
+    InjectorPluginReport processedReportDtoToInjectorPluginReport(ProcessedReportDTO report);
 
+    default List<DefectReport> mapInfoToDefectReports(LinkedHashMap<String, Object> info) {
+        return info.entrySet().stream()
+                .map(entry -> {
+                    var defectId = Integer.parseInt(entry.getKey());
+                    var value = (Map<String, Object>) entry.getValue();
+                    var file = String.valueOf(value.get("target"));
+                    List<Map<String, Object>> safes = (List<Map<String, Object>>) value.get("safe");
+                    List<SafeSpec> safeSpecs = safes.stream()
+                            .map(safe -> SafeSpec.builder().id(Integer.parseInt(String.valueOf(safe.get("id")))).build())
+                            .collect(Collectors.toUnmodifiableList());
+                    return DefectReport.builder()
+                            .defectId(defectId)
+                            .file(file)
+                            .safeSpecs(safeSpecs)
+                            .build();
+                })
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    // New method for transforming List<DefectReport> into List<InjectionTestDefectDto>
+    default List<InjectionTestDefectDto> defectReportsToInjectionTestDefectDtos(List<DefectReport> defectReports) {
+        return defectReports.stream()
+                .flatMap(defectReport -> defectReport.safeSpecs().stream()
+                        .map(safeSpec -> InjectionTestDefectDto.builder()
+                                .defectId(defectReport.defectId())
+                                .file(defectReport.file())
+                                .violationId(safeSpec.id())
+                                .build()))
+                .collect(Collectors.toList());
+    }
+
+    // Method to convert ProcessedReportDTO to List<InjectionTestDefectDto>
+    default List<InjectionTestDefectDto> processedReportDtoToInjectinoTestDefectDtos(ProcessedReportDTO report) {
+        List<DefectReport> defectReports = mapInfoToDefectReports(report.getInfo());
+        return defectReportsToInjectionTestDefectDtos(defectReports);
+    }
 }

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -50,6 +50,9 @@ public abstract class ProjectInformationMapper {
     @Mapping(target = "testResult", constant = "None")
     @Mapping(target = "failReason", ignore = true)
     @Mapping(target = "pluginProcessorId", ignore = true)
+    @Mapping(target = "injectorPluginReport", ignore = true)
+    @Mapping(target = "unitTestPluginReport", ignore = true)
+    @Mapping(target = "unitTestPluginRunResult", ignore = true)
     protected abstract ProjectInformation toEntryInternal(CreationProjectInformationDto createdDto);
 
 

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -155,35 +155,20 @@ public abstract class ProjectInformationMapper {
 
     protected void replaceTestSpecTaskFilePath(ProjectInformation target) {
 
-        var baseDirAbsolutePath = Paths.get(crichtonDataStorageProperties.getBasePath(), target.getId().toString()).toAbsolutePath();
+        final var baseDirAbsolutePath = Paths.get(crichtonDataStorageProperties.getBasePath(), target.getId().toString()).toAbsolutePath();
 
         try {
 
             Path testSpecFilePath = baseDirAbsolutePath.resolve(DirectoryName.DEFECT).resolve(FileName.TEST_SPEC);
-            var testSpecDto = ObjectMapperUtils.convertJsonToObject(testSpecFilePath.toFile(), TestSpecDto.class);
-
-            log.debug("Modify the File path value in '{}'.", testSpecFilePath.toAbsolutePath());
-            for(var taskDto : testSpecDto.getTasks()) {
-
-                var taskLocalFilePath = convertToLocalPath(baseDirAbsolutePath, taskDto.getFile());
-                taskDto.setFile(taskLocalFilePath);
-            }
 
             log.debug("Overwrite the modified values into file '{}'.", testSpecFilePath.toAbsolutePath());
-            ObjectMapperUtils.saveObjectToJsonFile(testSpecDto, testSpecFilePath.toFile());
+            ObjectMapperUtils.modifyJsonFile(testSpecFilePath, "tasks.file", (value) ->  convertToLocalPath(baseDirAbsolutePath, value), String.class);
 
 
             Path defectSpecFilePath = baseDirAbsolutePath.resolve(DirectoryName.DEFECT).resolve(FileName.DEFECT_SPEC);
-            var defectSpecs = ObjectMapperUtils.convertJsonToList(defectSpecFilePath, DefectSpec.class);
-
-            log.debug("Modify the File path value in '{}'.", defectSpecFilePath.toAbsolutePath());
-            for(var defectSpec : defectSpecs) {
-                var defectSpecLocaleFilePath = convertToLocalPath(baseDirAbsolutePath, defectSpec.getFilePath());
-                defectSpec.setFilePath(defectSpecLocaleFilePath);
-            }
 
             log.debug("Overwrite the modified values into file '{}'.", defectSpecFilePath.toAbsolutePath());
-            ObjectMapperUtils.saveObjectToJsonFile(defectSpecs, defectSpecFilePath.toFile());
+            ObjectMapperUtils.modifyJsonFile(defectSpecFilePath, "target", (value) ->  convertToLocalPath(baseDirAbsolutePath, value), String.class);
 
 
 
@@ -211,7 +196,6 @@ public abstract class ProjectInformationMapper {
         else {
             return localPath.toString();
         }
-
-
     }
+
 }

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -50,6 +50,7 @@ public abstract class ProjectInformationMapper {
     @Mapping(target = "status", constant = "None")
     @Mapping(target = "testResult", constant = "None")
     @Mapping(target = "failReason", ignore = true)
+    @Mapping(target = "pluginProcessorId", ignore = true)
     protected abstract ProjectInformation toEntryInternal(CreationProjectInformationDto createdDto);
 
 
@@ -96,14 +97,19 @@ public abstract class ProjectInformationMapper {
 
             if (dto.getDefectSpecFile() != null) {
 
-                var defectSpecs = ObjectMapperUtils.convertJsonToList(dto.getDefectSpecFile().getInputStream(), DefectSpec.class);
+                var defectSpecFilePath = FileUtils.getFilePath(defectDirectoryPath,  FileName.DEFECT_SPEC);
 
-                log.info("split defect spec file: {}", dto.getDefectSpecFile());
-                for (var defectSpec : defectSpecs) {
-                    var defectSpecFileName = FileName.DEFECT_SPEC.replace(".json", "_" + defectSpec.id() + ".json");
-                    var defectSpecFilePath = FileUtils.getFilePath(defectDirectoryPath,  defectSpecFileName);
-                    ObjectMapperUtils.saveObjectToJsonFile(defectSpec, defectSpecFilePath.toFile());
-                }
+                log.info("save defect spec file: {}", defectSpecFilePath);
+                saveFile(dto.getDefectSpecFile(), defectSpecFilePath);
+
+                var defectSpecs = ObjectMapperUtils.convertJsonToList(dto.getDefectSpecFile().getInputStream(), DefectSpec.class);
+//
+//                log.info("split defect spec file: {}", dto.getDefectSpecFile());
+//                for (var defectSpec : defectSpecs) {
+//                    var defectSpecFileName = FileName.DEFECT_SPEC.replace(".json", "_" + defectSpec.id() + ".json");
+//                    var defectSpecFilePath = FileUtils.getFilePath(defectDirectoryPath,  defectSpecFileName);
+//                    ObjectMapperUtils.saveObjectToJsonFile(defectSpec, defectSpecFilePath.toFile());
+//                }
 
                 dto.setDefectSpecs(defectSpecs);
             }

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -100,8 +100,6 @@ public abstract class ProjectInformationMapper {
 
                 log.info("save defect spec file: {}", defectSpecFilePath);
                 saveFile(dto.getDefectSpecFile(), defectSpecFilePath);
-
-                var defectSpecs = ObjectMapperUtils.convertJsonToList(dto.getDefectSpecFile().getInputStream(), DefectSpec.class);
 //
 //                log.info("split defect spec file: {}", dto.getDefectSpecFile());
 //                for (var defectSpec : defectSpecs) {
@@ -110,7 +108,6 @@ public abstract class ProjectInformationMapper {
 //                    ObjectMapperUtils.saveObjectToJsonFile(defectSpec, defectSpecFilePath.toFile());
 //                }
 
-                dto.setDefectSpecs(defectSpecs);
             }
 
             if (dto.getSafeSpecFile() != null) {

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ReportMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ReportMapper.java
@@ -1,0 +1,79 @@
+package org.crichton.domain.utils.mapper;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.crichton.configuration.CrichtonDataStorageProperties;
+import org.crichton.domain.dtos.report.InjectionTestDefectDto;
+import org.crichton.domain.dtos.report.ResponseReportDto;
+import org.crichton.domain.dtos.report.UnitTestDefectDto;
+import org.crichton.domain.entities.ProjectInformation;
+import org.crichton.models.report.DefectReport;
+import org.crichton.models.report.InjectorPluginReport;
+import org.crichton.models.report.UnitTestPluginReport;
+import org.crichton.models.safe.SafeSpec;
+import org.crichton.util.FileUtils;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Mapper(componentModel = "spring", imports = {UUID.class})
+public abstract class ReportMapper {
+
+    @Autowired
+    private CrichtonDataStorageProperties dataStorageProperties;
+
+
+    @Mapping(target = "injectionTestDefects", expression = "java(toInjectionTestDefects(projectInformation.getId(), projectInformation.getInjectorPluginReport()))")
+    @Mapping(target = "unitTestDefects", expression = "java(toUnitTestDefectDtos(projectInformation.getId(), projectInformation.getUnitTestPluginReport()))")
+    public abstract ResponseReportDto toResponseReportDto(@NonNull ProjectInformation projectInformation);
+
+    @Named("toInjectionTestDefects")
+    public List<InjectionTestDefectDto> toInjectionTestDefects(@NonNull UUID projectInformationId, InjectorPluginReport injectorPluginReport) {
+        if(injectorPluginReport != null) {
+            return toInjectionTestDefects(projectInformationId, injectorPluginReport.getDefectReports());
+        }
+        else {
+            return new ArrayList<>();
+        }
+    }
+
+    @Named("toInjectionTestDefects")
+    public List<InjectionTestDefectDto> toInjectionTestDefects(@NonNull UUID projectInformationId, @NonNull List<DefectReport> defectReports) {
+
+        String projectDirectoryPath = FileUtils.getAbsolutePath(dataStorageProperties.getBasePath(), projectInformationId.toString());
+
+        List<InjectionTestDefectDto> dtos = new ArrayList<>();
+        for (DefectReport defectReport : defectReports) {
+            String file = defectReport.file().replace(projectDirectoryPath, StringUtils.EMPTY).substring(1);
+
+            List<SafeSpec> safeSpecs = defectReport.safeSpecs().stream()
+                    .filter(safeSpec -> !safeSpec.isSuccess())
+                    .collect(Collectors.toUnmodifiableList());
+
+            for (SafeSpec safeSpec : safeSpecs) {
+                var dto = InjectionTestDefectDto.builder()
+                        .file(file)
+                        .defectId(defectReport.defectId())
+                        .violationId(safeSpec.id())
+                        .build();
+                dtos.add(dto);
+            }
+        }
+
+        return dtos;
+    }
+
+    @Named("mapToUnitTestDefectDtos")
+    public List<UnitTestDefectDto> toUnitTestDefectDtos(@NonNull UUID projectInformationId, UnitTestPluginReport unitTestPluginReport) {
+        return List.of();
+    }
+
+}

--- a/server/src/main/java/org/crichton/models/PluginProcessor.java
+++ b/server/src/main/java/org/crichton/models/PluginProcessor.java
@@ -20,7 +20,6 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 
 public class PluginProcessor implements Runnable {
@@ -80,15 +79,18 @@ public class PluginProcessor implements Runnable {
                 runUnitTesterPlugin();
             }
 
-            if(!injectorPluginRunResult.getIsSuccess()) {
+            if(unitTestPluginRunResult != null && !injectorPluginRunResult.getIsSuccess()) {
                 throw new RuntimeException("Injector Plugin processing failed");
             }
 
             if(unitTestPluginRunResult != null && !unitTestPluginRunResult.getIsSuccess()) {
                 throw new RuntimeException("Unit test Plugin processing failed");
             }
+            else {
+                ObjectMapperUtils.saveObjectToJsonFile(unitTestPluginRunResult, Paths.get(this.workingDirectoryPath, DirectoryName.UNIT_TEST).resolve("pluginResult.json").toFile());
+            }
 
-            targetProject.setInjectorPluginRunResult(InjectorPluginResultMapper.INSTANCE.processedReportDtoToInjectorPluginReport(injectorPluginRunResult.getData()));
+            targetProject.setInjectorPluginReport(InjectorPluginResultMapper.INSTANCE.processedReportDtoToInjectorPluginReport(injectorPluginRunResult.getData()));
             targetProject.setUnitTestPluginRunResult(unitTestPluginRunResult);
             targetProject.updateTestResult(TestResult.Success);
 

--- a/server/src/main/java/org/crichton/models/PluginProcessor.java
+++ b/server/src/main/java/org/crichton/models/PluginProcessor.java
@@ -66,9 +66,7 @@ public class PluginProcessor implements Runnable {
         try {
             log.info("Starting plugin processing...");
 
-            for (var defectSpec : targetProject.getDefectSpecs()) {
-                runDefectInjectorPlugin(defectSpec.id());
-            }
+            runDefectInjectorPlugin();
 
             if(Paths.get(this.unitTestPluginPath, FileName.UNIT_TESTER_PLUGIN).toFile().exists()) {
 //                runUnitTesterPlugin();
@@ -89,7 +87,7 @@ public class PluginProcessor implements Runnable {
         }
     }
 
-    private void runDefectInjectorPlugin(int defectSpecId) throws Exception {
+    private void runDefectInjectorPlugin() throws Exception {
 
         Map<String, String> defectInjectorConfiguration = new ConcurrentHashMap<>();
 
@@ -97,8 +95,9 @@ public class PluginProcessor implements Runnable {
 
         defectInjectorConfiguration.put(PluginConfigurationKey.WORKSPACE, this.workingDirectoryPath);
         defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.DIR_NAME, DirectoryName.DEFECT);
+        defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.DEFECT_MULTI_PROCESS_MODE, String.valueOf(Boolean.TRUE));
         defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.TEST_SPEC_FILE_NAME, FileName.TEST_SPEC);
-        defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.DEFECT_SPEC_FILE_NAME, FileName.DEFECT_SPEC.replace(".json", "_" + defectSpecId + ".json"));
+        defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.DEFECT_SPEC_FILE_NAME, FileName.DEFECT_SPEC);
         defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.SAFE_SPEC_FILE_NAME, FileName.SAFE_SPEC);
         defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.DEFECT_SIMULATION_OIL_FILE_NAME, FileName.DEFECT_SIMULATION_OIL);
         defectInjectorConfiguration.put(PluginConfigurationKey.DefectInjector.DEFECT_SIMULATION_EXE_FILE_NAME, FileName.DEFECT_SIMULATION_EXE);

--- a/server/src/main/java/org/crichton/models/defect/Bitflip.java
+++ b/server/src/main/java/org/crichton/models/defect/Bitflip.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.jackson.Jacksonized;
 
 @Builder
 @Getter
 @AllArgsConstructor
+@Jacksonized
 public class Bitflip {
 
     @JsonProperty("var")

--- a/server/src/main/java/org/crichton/models/defect/DefectSpec.java
+++ b/server/src/main/java/org/crichton/models/defect/DefectSpec.java
@@ -4,7 +4,5 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
-@Getter
 public record DefectSpec(int id, long trigger, long cycle, String target, @JsonProperty("defect") Spec spec) {
 }

--- a/server/src/main/java/org/crichton/models/defect/DefectSpec.java
+++ b/server/src/main/java/org/crichton/models/defect/DefectSpec.java
@@ -1,8 +1,15 @@
 package org.crichton.models.defect;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import org.crichton.models.safe.SafeSpec;
 
-public record DefectSpec(int id, long trigger, long cycle, String target, @JsonProperty("defect") Spec spec) {
+@Getter
+public class DefectSpec {
+
+    private String filePath;
+
+    private SafeSpec spec;
+
 }

--- a/server/src/main/java/org/crichton/models/defect/Spec.java
+++ b/server/src/main/java/org/crichton/models/defect/Spec.java
@@ -5,7 +5,5 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
-@Getter
 public record Spec(Bitflip bitflip) {
 }

--- a/server/src/main/java/org/crichton/models/report/DefectReport.java
+++ b/server/src/main/java/org/crichton/models/report/DefectReport.java
@@ -1,0 +1,11 @@
+package org.crichton.models.report;
+
+import lombok.Builder;
+import org.crichton.models.safe.SafeSpec;
+
+import java.util.List;
+
+@Builder
+public record DefectReport(int defectId, String file, List<SafeSpec> safeSpecs) {
+
+}

--- a/server/src/main/java/org/crichton/models/report/InjectorPluginReport.java
+++ b/server/src/main/java/org/crichton/models/report/InjectorPluginReport.java
@@ -1,0 +1,13 @@
+package org.crichton.models.report;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class InjectorPluginReport {
+    private String pluginName;
+    private List<DefectReport> defectReports;
+}

--- a/server/src/main/java/org/crichton/models/report/UnitTestPluginReport.java
+++ b/server/src/main/java/org/crichton/models/report/UnitTestPluginReport.java
@@ -1,0 +1,4 @@
+package org.crichton.models.report;
+
+public class UnitTestPluginReport {
+}

--- a/server/src/main/java/org/crichton/models/safe/SafeSpec.java
+++ b/server/src/main/java/org/crichton/models/safe/SafeSpec.java
@@ -4,5 +4,5 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Builder
-public record SafeSpec(int id) {
+public record SafeSpec(int id, boolean isSuccess) {
 }

--- a/server/src/main/java/org/crichton/models/safe/SafeSpec.java
+++ b/server/src/main/java/org/crichton/models/safe/SafeSpec.java
@@ -1,0 +1,8 @@
+package org.crichton.models.safe;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public record SafeSpec(int id) {
+}

--- a/server/src/main/java/org/crichton/util/ObjectMapperUtils.java
+++ b/server/src/main/java/org/crichton/util/ObjectMapperUtils.java
@@ -1,5 +1,6 @@
 package org.crichton.util;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,27 +14,34 @@ import java.util.List;
 
 public class ObjectMapperUtils {
 
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    static {
+        mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
     private ObjectMapperUtils() {
         throw new AssertionError();
     }
 
     public static <T> List<T> convertJsonToList(InputStream inputStream, Class<T> clazz) {
-        ObjectMapper objectMapper = new ObjectMapper();
+        mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         List<T> result = new ArrayList<>();
 
         try {
 
-            JsonNode jsonNode = objectMapper.readTree(inputStream);
+            JsonNode jsonNode = mapper.readTree(inputStream);
 
             // JSON이 배열인 경우
             if (jsonNode.isArray()) {
                 // InputStream을 다시 읽기 위해 리셋하거나, 다시 받아야 함
                 // 새로운 InputStream을 사용하여 배열을 처리
-                result = objectMapper.readValue(jsonNode.toString(), objectMapper.getTypeFactory().constructCollectionType(List.class, clazz));
+                result = mapper.readValue(jsonNode.toString(), mapper.getTypeFactory().constructCollectionType(List.class, clazz));
             }
             // JSON이 단일 객체인 경우
             else {
-                T obj = objectMapper.treeToValue(jsonNode, clazz);
+                T obj = mapper.treeToValue(jsonNode, clazz);
                 result.add(obj);  // 단일 객체를 리스트로 변환
             }
 
@@ -44,9 +52,8 @@ public class ObjectMapperUtils {
     }
 
     public static <T> T convertJsonStringToObject(String jsonString, Class<T> valueType) {
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
-            return objectMapper.readValue(jsonString, valueType);
+            return mapper.readValue(jsonString, valueType);
         } catch (Exception e) {
             throw new RuntimeException("Error converting JSON string to object", e);
         }
@@ -57,29 +64,24 @@ public class ObjectMapperUtils {
     }
 
     public static <T> T convertJsonFileToObject(File jsonFile, Class<T> valueType) {
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
-            return objectMapper.readValue(jsonFile, valueType);
+            return mapper.readValue(jsonFile, valueType);
         } catch (Exception e) {
             throw new RuntimeException("Error converting JSON string to object", e);
         }
     }
 
     public static String convertObjectToJsonString(Object object) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
         try {
-            return objectMapper.writeValueAsString(object);
+            return mapper.writeValueAsString(object);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Error converting object to JSON string", e);
         }
     }
 
     public static <T> void saveObjectToJsonFile(T object, String filePath) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
         try {
-            objectMapper.writeValue(new File(filePath), object);
+            mapper.writeValue(new File(filePath), object);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Error converting object to JSON string", e);
         } catch (IOException e) {
@@ -88,10 +90,8 @@ public class ObjectMapperUtils {
     }
 
     public static <T> void saveObjectToJsonFile(T object, File file) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
         try {
-            objectMapper.writeValue(file, object);
+            mapper.writeValue(file, object);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Error converting object to JSON string", e);
         } catch (IOException e) {

--- a/server/src/main/java/org/crichton/util/ObjectMapperUtils.java
+++ b/server/src/main/java/org/crichton/util/ObjectMapperUtils.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,8 +27,16 @@ public class ObjectMapperUtils {
         throw new AssertionError();
     }
 
+    public static <T> List<T> convertJsonToList(File jsonFile, Class<T> valueType) throws IOException {
+        return convertJsonToList(jsonFile.toPath(), valueType);
+    }
+
+    public static <T> List<T> convertJsonToList(Path jsonFilePath, Class<T> valueType) throws IOException {
+        return convertJsonToList(Files.newInputStream(jsonFilePath), valueType);
+    }
+
     public static <T> List<T> convertJsonToList(InputStream inputStream, Class<T> clazz) {
-        mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+
         List<T> result = new ArrayList<>();
 
         try {
@@ -46,9 +56,36 @@ public class ObjectMapperUtils {
             }
 
         }
-        catch (IOException e) {}
+        catch (IOException e) {
+            e.printStackTrace();
+        }
 
         return result;
+    }
+
+    public static <T> List<T> convertJsonContentToList(String jsonString, Class<T> valueType) {
+
+        List<T> result = new ArrayList<>();
+
+        try {
+            JsonNode jsonNode = mapper.readTree(jsonString);
+
+            // JSON이 배열인 경우
+            if (jsonNode.isArray()) {
+                // InputStream을 다시 읽기 위해 리셋하거나, 다시 받아야 함
+                // 새로운 InputStream을 사용하여 배열을 처리
+                result = mapper.readValue(jsonNode.toString(), mapper.getTypeFactory().constructCollectionType(List.class, valueType));
+            }
+            // JSON이 단일 객체인 경우
+            else {
+                T obj = mapper.treeToValue(jsonNode, valueType);
+                result.add(obj);  // 단일 객체를 리스트로 변환
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting JSON string to object", e);
+        }
     }
 
     public static <T> T convertJsonStringToObject(String jsonString, Class<T> valueType) {
@@ -59,11 +96,15 @@ public class ObjectMapperUtils {
         }
     }
 
-    public static <T> T convertJsonFileToObject(String jsonFile, Class<T> valueType) {
-        return convertJsonFileToObject(new File(jsonFile), valueType);
+    public static <T> T convertJsonToObject(String jsonFile, Class<T> valueType) {
+        return convertJsonToObject(new File(jsonFile), valueType);
     }
 
-    public static <T> T convertJsonFileToObject(File jsonFile, Class<T> valueType) {
+    public static <T> T convertJsonToObject(Path jsonFile, Class<T> valueType) {
+        return convertJsonToObject(jsonFile.toFile(), valueType);
+    }
+
+    public static <T> T convertJsonToObject(File jsonFile, Class<T> valueType) {
         try {
             return mapper.readValue(jsonFile, valueType);
         } catch (Exception e) {
@@ -80,13 +121,7 @@ public class ObjectMapperUtils {
     }
 
     public static <T> void saveObjectToJsonFile(T object, String filePath) {
-        try {
-            mapper.writeValue(new File(filePath), object);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Error converting object to JSON string", e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        saveObjectToJsonFile(object, new File(filePath));
     }
 
     public static <T> void saveObjectToJsonFile(T object, File file) {

--- a/server/src/main/java/org/crichton/util/ObjectMapperUtils.java
+++ b/server/src/main/java/org/crichton/util/ObjectMapperUtils.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.crichton.util.functional.ValueModifier;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +28,88 @@ public class ObjectMapperUtils {
 
     private ObjectMapperUtils() {
         throw new AssertionError();
+    }
+
+    // JSON 파일의 특정 키에 대해 값을 수정하는 함수 (내부 객체까지 탐색)
+    public static <T> void modifyJsonFile(String filePath, String key, ValueModifier<T> modifier, Class<T> valueType) throws IOException {
+        // JSON 파일을 읽기
+        modifyJsonFile(new File(filePath), key, modifier, valueType);
+    }
+    public static <T> void modifyJsonFile(Path jsonFilePath, String keyPath, ValueModifier<T> modifier, Class<T> valueType) throws IOException {
+        // JSON 파일을 읽기
+        modifyJsonFile(jsonFilePath.toFile(), keyPath, modifier, valueType);
+    }
+
+    public static <T> void modifyJsonFile(File jsonFile, String keyPath, ValueModifier<T> modifier, Class<T> valueType) throws IOException {
+        // JSON 파일을 읽기
+        JsonNode root = mapper.readTree(jsonFile);
+
+        // JSON 구조 탐색하여 값 수정
+        // 루트가 배열인 경우 배열 처리
+        if (root.isArray()) {
+            ArrayNode arrayNode = (ArrayNode) root;
+            for (JsonNode element : arrayNode) {
+                modifyJsonNode(element, keyPath.split("\\."), 0, modifier, valueType);
+            }
+        } else {
+            // 중첩된 키 탐색 및 값 수정 (루트가 배열이 아닌 경우)
+            modifyJsonNode(root, keyPath.split("\\."), 0, modifier, valueType);
+        }
+
+        // 수정된 내용을 다시 파일에 덮어쓰기
+        mapper.writeValue(jsonFile, root);
+    }
+
+    // JsonNode에서 특정 키에 대해 값을 수정 (내부 객체 및 배열 포함)
+    private static  <T> void modifyJsonNode(JsonNode node, String[] keyPath, int depth, ValueModifier<T> modifier, Class<T> valueType) {
+
+        if (node == null || keyPath.length == 0) {
+            return;
+        }
+
+        String currentKey = keyPath[depth];
+        JsonNode currentNode = node.get(currentKey);
+
+        if (currentNode == null) {
+            return;  // 현재 노드가 null이면 더 이상 탐색하지 않음
+        }
+
+        // 마지막 키에 도달했을 때 단순 값을 처리
+        if (depth == keyPath.length - 1) {
+            if (currentNode.isValueNode()) {  // TextNode, NumberNode 등의 단순 값 처리
+                modifyKeyValue((ObjectNode) node, currentKey, modifier, valueType);
+            }
+        } else {
+            // 중간 경로가 배열인 경우
+            if (currentNode.isArray()) {
+                ArrayNode arrayNode = (ArrayNode) currentNode;
+                for (JsonNode element : arrayNode) {
+                    modifyJsonNode(element, keyPath, depth + 1, modifier, valueType);  // 배열 요소에 대해 남은 경로 탐색
+                }
+            }
+            // 중간 경로가 객체인 경우
+            else if (currentNode.isObject()) {
+                modifyJsonNode(currentNode, keyPath, depth + 1, modifier, valueType);  // 객체일 경우 재귀적 탐색
+            }
+        }
+
+
+
+    }
+
+    // ObjectNode에서 특정 key의 값을 수정하는 로직
+    private static <T> void modifyKeyValue(ObjectNode objectNode, String keyPath, ValueModifier<T> modifier, Class<T> valueType) {
+        JsonNode currentNode = objectNode.get(keyPath);
+        if (currentNode != null) {
+            // 현재 값을 지정한 타입으로 변환
+            T currentValue = mapper.convertValue(currentNode, valueType);
+
+            // 인터페이스에서 제공된 로직으로 값 수정
+            T modifiedValue = modifier.modifyValue(currentValue);
+
+            // 수정된 값으로 덮어쓰기 (타입에 따라 다르게 처리)
+            objectNode.putPOJO(keyPath, modifiedValue);
+        }
     }
 
     public static <T> List<T> convertJsonToList(File jsonFile, Class<T> valueType) throws IOException {

--- a/server/src/main/java/org/crichton/util/functional/ValueModifier.java
+++ b/server/src/main/java/org/crichton/util/functional/ValueModifier.java
@@ -1,0 +1,7 @@
+package org.crichton.util.functional;
+
+// 값 수정 로직을 정의하는 인터페이스
+@FunctionalInterface
+public interface ValueModifier<T> {
+    T modifyValue(T currentValue);
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -35,6 +35,7 @@ spring.jackson.default-property-inclusion=non_null
 spring.jackson.serialization.indent-output=true
 
 # logging
+logging.file.path=
 logging.file.name=${user.home}/.crichton/logs/crichton-server.log
 crichton.data.storage.base-path=${user.home}/.crichton/data
 crichton.plugin.injector-path=${user.dir}/plugins/injector

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -30,3 +30,6 @@ spring.servlet.multipart.maxRequestSize=-1
 # Swagger
 springdoc.swagger-ui.path=/swagger-ui
 springdoc.swagger-ui.disable-swagger-default-url=true
+
+spring.jackson.default-property-inclusion=non_null
+spring.jackson.serialization.indent-output=true

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -33,3 +33,9 @@ springdoc.swagger-ui.disable-swagger-default-url=true
 
 spring.jackson.default-property-inclusion=non_null
 spring.jackson.serialization.indent-output=true
+
+# logging
+logging.file.name=${user.home}/.crichton/logs/crichton-server.log
+crichton.data.storage.base-path=${user.home}/.crichton/data
+crichton.plugin.injector-path=${user.dir}/plugins/injector
+crichton.plugin.unit-tester-path=${user.dir}/plugins/unit-tester

--- a/server/src/main/resources/logback-config.xml
+++ b/server/src/main/resources/logback-config.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- crichton.properties에서 로그 파일 경로 가져오기 -->
+    <property name="LOG_FILE" value="${logging.file.name:${user.home}/.crichton/logs/crichton-server.log}" />
+
+    <!-- RollingFileAppender 설정 -->
+    <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+
+        <!-- 파일 롤링 정책: 파일 크기와 보관 설정 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- 파일 이름 패턴 (날짜와 순번 포함) -->
+            <fileNamePattern>${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <!-- 각 파일의 최대 크기 설정 -->
+            <maxFileSize>10MB</maxFileSize>
+            <!-- 보관할 파일의 최대 개수 설정 -->
+            <maxHistory>7</maxHistory>
+            <!-- 전체 보관 용량 제한 -->
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 루트 로거 설정 (필수) -->
+    <root level="info">
+        <appender-ref ref="ROLLING" />
+    </root>
+
+</configuration>

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
 
     <!-- crichton.properties에서 로그 파일 경로 가져오기 -->
-    <property name="LOG_FILE" value="${logging.file.name:${user.home}/.crichton/logs/crichton-server.log}" />
+    <property name="LOG_FILE" value="${logging.file.name:${user.home}/.crichton/logs/crichton-server.log}" resource="crichton.properties" />
 
     <!-- RollingFileAppender 설정 -->
     <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -28,6 +28,7 @@
     <!-- 루트 로거 설정 (필수) -->
     <root level="info">
         <appender-ref ref="ROLLING" />
+        <appender-ref ref="CONSOLE" />
     </root>
 
 </configuration>


### PR DESCRIPTION
- Injector 플러그인에 결함 스펙 정보가 여러개 있는 파일을 분할 하여 결함 주입 수만큼 플러그인 내의 프로세스 수행
- 분할된 파일을 처리 할수 있도록 멀티모드 추가
- 멀티모드일때 Injector 플러그인에 사용되는 결함 스펙 JSON 파일이 JSON 배열이 아닌 Object인경우 배열화 하여 처리하도록 수정
- 스펙상 파일 경로를 오브젝트가 아닌 JSONNode 클래스로 만처리하도록 수정
- 결함 주입 플러그인 결과 값 데이터화 처리
- 서버 로그를 파일로 저장 하도록 처리 및 설정 파일 추가