### PR TITLE
[feature] 분석 명세 JSON 파일 통합에 따른 기능 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ server/gradlew.bat
 client/node_modules
 server/crichton/**
 **/.vs
+*.pid

--- a/plugins/injector/src/main/java/injector/DefectInjectorPlugin.java
+++ b/plugins/injector/src/main/java/injector/DefectInjectorPlugin.java
@@ -45,10 +45,6 @@ public class DefectInjectorPlugin implements Plugin {
         }
 
         this.setting = new DefectInjectorSetting(pluginOption.pluginName(), pluginOption.pluginSetting());
-
-        if(this.setting.isMultiMode()) {
-            setting.splitDefectSpecFile();
-        }
 //        setting.makeDefectJson();
     }
 

--- a/plugins/injector/src/main/java/injector/process/DefectInjectorRunner.java
+++ b/plugins/injector/src/main/java/injector/process/DefectInjectorRunner.java
@@ -32,7 +32,7 @@ public class DefectInjectorRunner extends DotnetProcessRunner {
 
         var arguments = List.of(
                 targetSource,
-                setting.getTestSpecFile(),
+                getTestSpecFile(),
                 getDefectSpecFile(),
                 setting.getSafeSpecFile(),
                 setting.getTrampoline()
@@ -41,6 +41,15 @@ public class DefectInjectorRunner extends DotnetProcessRunner {
         CommandBuilder command = this.buildCommand(setting.getDefectInjectorEngine(), arguments);
 
         return command;
+    }
+
+    private String getTestSpecFile() {
+        if(Objects.isNull(defectSpecId)) {
+            return setting.getTestSpecFile();
+        }
+        else {
+            return setting.getTestSpecFile(defectSpecId);
+        }
     }
 
     private String getDefectSpecFile() {

--- a/plugins/injector/src/main/java/injector/utils/DefectInjectorFileUtils.java
+++ b/plugins/injector/src/main/java/injector/utils/DefectInjectorFileUtils.java
@@ -1,0 +1,35 @@
+package injector.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+public class DefectInjectorFileUtils {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private DefectInjectorFileUtils() {
+        throw new AssertionError();
+    }
+
+    public static String getTestSpecFileName(String defectJsonFile) throws IOException, NoSuchElementException {
+        var jsonNode = mapper.readTree(new File(defectJsonFile));
+        if(!jsonNode.has("build")) {
+            throw new NoSuchElementException(defectJsonFile + " does not have build");
+        }
+        return jsonNode.get("build").asText();
+    }
+
+    public static String getTargetFileName(String defectJsonFile) {
+        try {
+            JsonNode rootNode = mapper.readTree(new File(defectJsonFile));
+            return rootNode.get("target").asText();
+        } catch (Exception e){
+            return "";
+        }
+    }
+
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -225,6 +225,8 @@ dependencies {
     // 파일 및 압축 관련 유틸리티
     implementation group: 'org.zeroturnaround', name: 'zt-zip', version: '1.14' // zt-zip for ZIP file handling
     implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.5' // Zip4j for advanced ZIP handling
+    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.27.1' // commons-compress for advanced ZIP, TAR, TAR.GZ and etc handling
+
 
     // 기타 유틸리티 라이브러리
     implementation group: 'org.scala-lang', name: 'scala3-library_3', version: '3.1.0' // Scala 라이브러리

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -233,7 +233,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0' // Apache Commons Lang
     implementation 'org.junit.jupiter:junit-jupiter-api' // JUnit for Testing
     implementation group: 'org.zeroturnaround', name: 'zt-exec', version: '1.12' // zt-exec for process handling
-    implementation group: 'commons-io', name: 'commons-io', version: '2.13.0' // Apache Commons IO
+    implementation group: 'commons-io', name: 'commons-io', version: '2.18.0' // Apache Commons IO
     implementation 'org.apache.tika:tika-core:2.9.2'    // Apache Tika
 
     implementation group: 'com.github.oshi', name: 'oshi-core', version: '6.6.5'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -163,6 +163,18 @@ task prepareDeploymentServer (dependsOn: [copyJar, copyConfig]) {
     }
 }
 
+tasks.test {
+    useJUnitPlatform() // JUnit 5 (Jupiter) 플랫폼 사용
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+    }
+    // 보고서 설정
+    reports {
+        junitXml.required.set(true) // XML 보고서 활성화
+        html.required.set(true)    // HTML 보고서 활성화
+    }
+}
+
 
 
 
@@ -207,6 +219,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
 
     // 파일 및 압축 관련 유틸리티
     implementation group: 'org.zeroturnaround', name: 'zt-zip', version: '1.14' // zt-zip for ZIP file handling

--- a/server/src/main/java/org/crichton/domain/dtos/project/CreationProjectInformationDto.java
+++ b/server/src/main/java/org/crichton/domain/dtos/project/CreationProjectInformationDto.java
@@ -27,20 +27,12 @@ public class CreationProjectInformationDto {
     private MultipartFile testSpecFile;
 
     @Setter
-    @ValidFile(allowFileDefines = { JSON }, message = "Only JSON files are allowed for defectSpecFile")
-    private MultipartFile defectSpecFile;
-
-    @Setter
     @ValidFile(allowFileDefines = { JSON}, message = "Only JSON files are allowed for safeSpecFile")
     private MultipartFile safeSpecFile;
 
     @Setter
     @ValidFile(allowFileDefines = { JSON }, required = false, message = "Only JSON files are allowed for unitTestSpecFile")
     private MultipartFile unitTestSpecFile;
-
-    @Setter
-    @JsonIgnore
-    private TestSpecDto testSpec = TestSpecDto.builder().build();
 
     @Setter
     @JsonIgnore

--- a/server/src/main/java/org/crichton/domain/entities/ProjectInformation.java
+++ b/server/src/main/java/org/crichton/domain/entities/ProjectInformation.java
@@ -17,9 +17,6 @@ public class ProjectInformation {
 
     private UUID id;
 
-    @Setter
-    private TestSpec testSpec;
-
     private ProjectStatus status;
 
     private TestResult testResult;

--- a/server/src/main/java/org/crichton/domain/utils/enums/UploadAllowFileDefine.java
+++ b/server/src/main/java/org/crichton/domain/utils/enums/UploadAllowFileDefine.java
@@ -3,6 +3,8 @@ package org.crichton.domain.utils.enums;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 @AllArgsConstructor
 public enum UploadAllowFileDefine {
@@ -21,4 +23,47 @@ public enum UploadAllowFileDefine {
 
     private final String fileExtensionLowerCase; // 파일 확장자(소문자)
     private final String[] allowMimeTypes; // 허용하는 MIME 타입들
+
+    /**
+     * 주어진 MIME 타입이 열거형에 정의된 MIME 타입 중 하나인지 확인
+     */
+    public static UploadAllowFileDefine getByMimeType(String mimeType) {
+        for (UploadAllowFileDefine define : values()) {
+            for (String allowedMimeType : define.getAllowMimeTypes()) {
+                if (allowedMimeType.equalsIgnoreCase(mimeType)) {
+                    return define;
+                }
+            }
+        }
+        return null; // 지원되지 않는 MIME 타입인 경우 null 반환
+    }
+
+    /**
+     * 주어진 파일 확장자가 열거형에 정의된 확장자와 일치하는지 확인
+     */
+    public static UploadAllowFileDefine getByFileExtension(String fileExtension) {
+        for (UploadAllowFileDefine define : values()) {
+            if (define.getFileExtensionLowerCase().equalsIgnoreCase(fileExtension)) {
+                return define;
+            }
+        }
+        return null; // 지원되지 않는 파일 확장자인 경우 null 반환
+    }
+
+    /**
+     * MIME 타입과 파일 확장자를 동시에 확인
+     */
+    public static UploadAllowFileDefine getByMimeTypeAndExtension(String mimeType, String fileExtension) {
+        for (UploadAllowFileDefine define : values()) {
+            if (define.getFileExtensionLowerCase().equalsIgnoreCase(fileExtension)) {
+                for (String allowedMimeType : define.getAllowMimeTypes()) {
+                    if (allowedMimeType.equalsIgnoreCase(mimeType)) {
+                        return define;
+                    }
+                }
+            }
+        }
+        return null; // 둘 다 일치하지 않는 경우 null 반환
+    }
+
 }

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -46,8 +46,20 @@ public abstract class ProjectInformationMapper {
         var entity = toEntryInternal(createdDto);
 
         var baseDirAbsolutePath = Paths.get(crichtonDataStorageProperties.getBasePath(), entity.getId().toString()).toAbsolutePath();
-        processAndSplitTestSpecFiles(baseDirAbsolutePath);
-        replaceTestSpecTaskFilePath(baseDirAbsolutePath);
+        try {
+            processAndSplitTestSpecFiles(baseDirAbsolutePath);
+            replaceTestSpecTaskFilePath(baseDirAbsolutePath);
+        }
+        catch (Exception e) {
+            if(baseDirAbsolutePath.toFile().exists()) {
+                try {
+                    FileUtils.deleteDirectoryRecursively(baseDirAbsolutePath);
+                } catch (IOException e1) {
+                    throw new IOException(e1);
+                }
+            }
+            throw e;
+        }
         return entity;
     };
 

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -1,5 +1,6 @@
 package org.crichton.domain.utils.mapper;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import org.crichton.configuration.CrichtonDataStorageProperties;
@@ -22,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.UUID;
 
 @Mapper(componentModel = "spring", imports = {UUID.class}, uses = { TestSpecMapper.class })
@@ -36,10 +38,13 @@ public abstract class ProjectInformationMapper {
     private OperationSystemUtil operationSystemUtil;
 
 
-    public ProjectInformation toEntry(CreationProjectInformationDto createdDto) throws IOException {
+    public ProjectInformation toEntry(CreationProjectInformationDto createdDto) throws IOException, NoSuchFieldException {
         createFiles(createdDto);
         var entity = toEntryInternal(createdDto);
-        replaceTestSpecTaskFilePath(entity);
+
+        var baseDirAbsolutePath = Paths.get(crichtonDataStorageProperties.getBasePath(), entity.getId().toString()).toAbsolutePath();
+        processAndSplitTestSpecFiles(baseDirAbsolutePath);
+        replaceTestSpecTaskFilePath(baseDirAbsolutePath);
         return entity;
     };
 
@@ -92,11 +97,6 @@ public abstract class ProjectInformationMapper {
 
                 log.info("save test spec file: {}", testSpecFilePath);
                 saveFile(dto.getTestSpecFile(), testSpecFilePath);
-
-                log.info("Updated JSON file content: {}", testSpecFilePath);
-                var jsonString = Files.readString(testSpecFilePath);
-                var testSpecDto = ObjectMapperUtils.convertJsonStringToObject(jsonString, TestSpecDto.class);
-                dto.setTestSpec(testSpecDto);
             }
 
             if (dto.getSafeSpecFile() != null) {
@@ -139,24 +139,64 @@ public abstract class ProjectInformationMapper {
         }
     }
 
-    protected void replaceTestSpecTaskFilePath(ProjectInformation target) {
+    @SuppressWarnings("unchecked")
+    private void processAndSplitTestSpecFiles(Path baseDirectory) throws IOException, NoSuchFieldException {
 
-        final var baseDirAbsolutePath = Paths.get(crichtonDataStorageProperties.getBasePath(), target.getId().toString()).toAbsolutePath();
+        Path testSpecFilePath = baseDirectory.resolve(DirectoryName.INJECT_TEST).resolve(FileName.TEST_SPEC);
+        var jsonNode = ObjectMapperUtils.getJsonNode(testSpecFilePath.toFile());
+
+        Path injectSpecFilesStoreDirectoryPath = baseDirectory.resolve(DirectoryName.INJECT_TEST);
+        splitDefectsToFile(jsonNode, injectSpecFilesStoreDirectoryPath.resolve(FileName.DEFECT_SPEC));
+        splitBuildsToFiles(jsonNode, injectSpecFilesStoreDirectoryPath);
+    }
+
+    private void splitDefectsToFile(JsonNode jsonNode, Path defectSpecFilePath) throws NoSuchFieldException {
+        if (jsonNode.has("defects")) {
+            log.info("Saving defects to file: {}", defectSpecFilePath);
+            ObjectMapperUtils.saveObjectToJsonFile(jsonNode.get("defects"), defectSpecFilePath.toFile());
+        } else {
+            throw new NoSuchFieldException("Key 'defects' not found in the test specification JSON.");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void splitBuildsToFiles(JsonNode jsonNode, Path injectorDirectoryPath) throws NoSuchFieldException {
+        if (jsonNode.has("builds")) {
+            Map<String, Object> builds = ObjectMapperUtils.convertValue(jsonNode.get("builds"), Map.class);
+            for (var entry : builds.entrySet()) {
+                String buildSpecFileName = entry.getKey() + ".json";
+                Path buildSpecFilePath = injectorDirectoryPath.resolve(buildSpecFileName);
+                log.info("Saving build '{}' to file: {}", entry.getKey(), buildSpecFilePath);
+                ObjectMapperUtils.saveObjectToJsonFile(entry.getValue(), buildSpecFilePath.toFile());
+            }
+        } else {
+            throw new NoSuchFieldException("Key 'builds' not found in the test specification JSON.");
+        }
+    }
+
+    protected void replaceTestSpecTaskFilePath(final Path baseDirAbsolutePath) {
 
         try {
 
             final Path sourceDirAbsolutePath = baseDirAbsolutePath.resolve(DirectoryName.SOURCE);
 
-            Path testSpecFilePath = baseDirAbsolutePath.resolve(DirectoryName.INJECT_TEST).resolve(FileName.TEST_SPEC);
-
-            log.debug("Overwrite the modified values into file '{}'.", testSpecFilePath.toAbsolutePath());
-            ObjectMapperUtils.modifyJsonFile(testSpecFilePath, "tasks.file", (value) ->  convertToLocalPath(sourceDirAbsolutePath, value), String.class);
-
-
+            final Path injectTesterDirectoryPath = baseDirAbsolutePath.resolve(DirectoryName.INJECT_TEST).toAbsolutePath();
             Path defectSpecFilePath = baseDirAbsolutePath.resolve(DirectoryName.INJECT_TEST).resolve(FileName.DEFECT_SPEC);
 
             log.debug("Overwrite the modified values into file '{}'.", defectSpecFilePath.toAbsolutePath());
             ObjectMapperUtils.modifyJsonFile(defectSpecFilePath, "target", (value) ->  convertToLocalPath(sourceDirAbsolutePath, value), String.class);
+            ObjectMapperUtils.modifyJsonFile(defectSpecFilePath, "build", (value) ->  {
+                var buildSpecFile = convertToLocalPath(injectTesterDirectoryPath, String.format("%s.json", value));
+
+                Path buildSpecFilePath = Path.of(buildSpecFile);
+
+                log.debug("Overwrite the modified values into file '{}'.", buildSpecFilePath.toAbsolutePath());
+//                ObjectMapperUtils.modifyJsonFile(buildSpecFile, "tasks.file", (fileName) ->  convertToLocalPath(sourceDirAbsolutePath, fileName), String.class);
+                ObjectMapperUtils.modifyJsonFile(buildSpecFile, "extra_srcs", (fileName) ->  convertToLocalPath(sourceDirAbsolutePath, fileName), String.class);
+
+
+                return buildSpecFile;
+            }, String.class);
 
 
 

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -99,22 +99,6 @@ public abstract class ProjectInformationMapper {
                 dto.setTestSpec(testSpecDto);
             }
 
-            if (dto.getDefectSpecFile() != null) {
-
-                var defectSpecFilePath = FileUtils.getFilePath(defectDirectoryPath,  FileName.DEFECT_SPEC);
-
-                log.info("save defect spec file: {}", defectSpecFilePath);
-                saveFile(dto.getDefectSpecFile(), defectSpecFilePath);
-//
-//                log.info("split defect spec file: {}", dto.getDefectSpecFile());
-//                for (var defectSpec : defectSpecs) {
-//                    var defectSpecFileName = FileName.DEFECT_SPEC.replace(".json", "_" + defectSpec.id() + ".json");
-//                    var defectSpecFilePath = FileUtils.getFilePath(defectDirectoryPath,  defectSpecFileName);
-//                    ObjectMapperUtils.saveObjectToJsonFile(defectSpec, defectSpecFilePath.toFile());
-//                }
-
-            }
-
             if (dto.getSafeSpecFile() != null) {
                 var safeSpecFilePath = FileUtils.getFilePath(defectDirectoryPath, FileName.SAFE_SPEC);
 

--- a/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/ProjectInformationMapper.java
@@ -87,7 +87,7 @@ public abstract class ProjectInformationMapper {
             // sourceCode 파일 압축 해제
             if (dto.getSourceCode() != null) {
                 log.info("unzip source file: {}", dto.getSourceCode());
-                unzipFile(dto.getSourceCode(), sourceDirectoryPath);
+                FileUtils.CompressFile.extractFile(dto.getSourceCode(), sourceDirectoryPath);
             }
 
             // 나머지 파일 저장
@@ -125,18 +125,6 @@ public abstract class ProjectInformationMapper {
     private String saveFile(MultipartFile file, Path filePath) throws IOException {
         Files.write(filePath, file.getBytes());
         return filePath.toString();
-    }
-
-    // Zip4j를 사용한 압축 해제 메서드
-    private void unzipFile(MultipartFile zipFile, String destDir) throws IOException, ZipException {
-        File tempZipFile = Files.createTempFile("temp", ".zip").toFile();
-        zipFile.transferTo(tempZipFile);
-
-        try (ZipFile zip = new ZipFile(tempZipFile)) {
-            zip.extractAll(destDir);
-        } finally {
-            tempZipFile.delete();
-        }
     }
 
     @SuppressWarnings("unchecked")
@@ -191,7 +179,7 @@ public abstract class ProjectInformationMapper {
                 Path buildSpecFilePath = Path.of(buildSpecFile);
 
                 log.debug("Overwrite the modified values into file '{}'.", buildSpecFilePath.toAbsolutePath());
-//                ObjectMapperUtils.modifyJsonFile(buildSpecFile, "tasks.file", (fileName) ->  convertToLocalPath(sourceDirAbsolutePath, fileName), String.class);
+                ObjectMapperUtils.modifyJsonFile(buildSpecFile, "tasks.file", (fileName) ->  convertToLocalPath(sourceDirAbsolutePath, fileName), String.class);
                 ObjectMapperUtils.modifyJsonFile(buildSpecFile, "extra_srcs", (fileName) ->  convertToLocalPath(sourceDirAbsolutePath, fileName), String.class);
 
 

--- a/server/src/main/java/org/crichton/domain/utils/mapper/report/ReportMapper.java
+++ b/server/src/main/java/org/crichton/domain/utils/mapper/report/ReportMapper.java
@@ -15,6 +15,7 @@ import org.crichton.models.report.UnitTestPluginReport;
 import org.crichton.models.report.UnitTestReport;
 import org.crichton.models.safe.SafeSpec;
 import org.crichton.util.FileUtils;
+import org.crichton.util.constants.DirectoryName;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -49,7 +50,7 @@ public abstract class ReportMapper {
     @Named("toInjectionTestDefects")
     public List<InjectionTestDefectDto> toInjectionTestDefects(@NonNull UUID projectInformationId, @NonNull List<InjectorDefectReport> injectorDefectReports) {
 
-        String projectDirectoryPath = FileUtils.getAbsolutePath(dataStorageProperties.getBasePath(), projectInformationId.toString());
+        String projectDirectoryPath = FileUtils.getAbsolutePath(dataStorageProperties.getBasePath(), projectInformationId.toString(), DirectoryName.SOURCE);
 
         List<InjectionTestDefectDto> dtos = new ArrayList<>();
         for (InjectorDefectReport injectorDefectReport : injectorDefectReports) {

--- a/server/src/main/java/org/crichton/domain/utils/vaildators/FileTypeValidator.java
+++ b/server/src/main/java/org/crichton/domain/utils/vaildators/FileTypeValidator.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.tika.Tika;
 import org.crichton.domain.utils.anotations.ValidFile;
 import org.crichton.domain.utils.enums.UploadAllowFileDefine;
+import org.crichton.util.FileUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -83,7 +84,7 @@ public class FileTypeValidator implements ConstraintValidator<ValidFile, Multipa
         }
 
         //허용된 파일 확장자 검사
-        final String detectedMediaType = this.getMimeTypeByTika(file); //확장자 변조한 파일인지 확인을 위한 mime type 얻기
+        final String detectedMediaType = FileUtils.getMimeTypeByTika(file); //확장자 변조한 파일인지 확인을 위한 mime type 얻기
 
         //파일 변조 업로드를 막기위한 mime타입 검사(예. exe파일을 csv로 확장자 변경하는 업로드를 막음)
         if (!ArrayUtils.contains(allowMimeTypes, detectedMediaType)) {
@@ -98,35 +99,6 @@ public class FileTypeValidator implements ConstraintValidator<ValidFile, Multipa
     }
 
 
-    /**
-     * apache Tika라이브러리를 이용해서 파일의 mimeType을 가져옴
-     *
-     * @param multipartFile
-     * @return
-     */
-    private String getMimeTypeByTika(MultipartFile multipartFile) {
-        try(var inputStream = multipartFile.getInputStream()) {
 
-            Tika tika = new Tika();
-
-            // MIME 타입 감지
-            String mimeType = tika.detect(inputStream);
-            log.debug("업로드 요청된 파일 {}의 mimeType:{}", multipartFile.getOriginalFilename(), mimeType);
-
-            // 확장자가 .json이면서 mimeType이 text/plain이거나 application/octet-stream인 경우,
-            // application/json으로 설정
-            String fileExtension = FilenameUtils.getExtension(multipartFile.getOriginalFilename());
-            if ("json".equalsIgnoreCase(fileExtension) &&
-                    ("text/plain".equalsIgnoreCase(mimeType) || "application/octet-stream".equalsIgnoreCase(mimeType))) {
-                mimeType = "application/json";
-            }
-
-            return mimeType;
-
-        } catch (IOException e) {
-            log.error(e.getMessage(), e);
-            return null;
-        }
-    }
 
 }

--- a/server/src/main/java/org/crichton/util/FileUtils.java
+++ b/server/src/main/java/org/crichton/util/FileUtils.java
@@ -3,6 +3,8 @@ package org.crichton.util;
 import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -219,8 +221,26 @@ public class FileUtils {
         }
 
         public static void unzipFile(File zipFile, String destDir) throws IOException {
-            try (net.lingala.zip4j.ZipFile zip = new net.lingala.zip4j.ZipFile(zipFile)) {
-                zip.extractAll(destDir);
+            try (ZipFile zip = new ZipFile(zipFile)) {
+                // ZIP 파일의 모든 항목 가져오기
+                for (FileHeader fileHeader : zip.getFileHeaders()) {
+                    if (!fileHeader.isDirectory()) {
+                        // 항목의 원래 경로 가져오기
+                        String entryName = fileHeader.getFileName();
+
+                        // 최상위 디렉토리 제거
+                        String relativePath = removeTopLevelDirectory(entryName);
+
+                        // 대상 파일 경로 계산
+                        File outputFile = new File(destDir, relativePath);
+                        outputFile.getParentFile().mkdirs(); // 필요한 디렉토리 생성
+
+                        // 파일 추출
+                        zip.extractFile(fileHeader, outputFile.getParent(), outputFile.getName());
+                    }
+                }
+            } catch (ZipException e) {
+                throw new IOException("Failed to extract ZIP file", e);
             }
         }
 
@@ -245,11 +265,20 @@ public class FileUtils {
         public static void extractTarArchive(TarArchiveInputStream tis, String destDir) throws IOException {
             TarArchiveEntry entry;
             while ((entry = tis.getNextTarEntry()) != null) {
-                File outputFile = new File(destDir, entry.getName());
+                // 디렉토리 정보 처리
+                String entryName = entry.getName();
+
+                // 최상위 디렉토리 제거
+                String relativePath = removeTopLevelDirectory(entryName);
+
+                // 파일 또는 디렉토리를 생성
+                File outputFile = new File(destDir, relativePath);
                 if (entry.isDirectory()) {
+                    // 디렉토리 생성
                     outputFile.mkdirs();
                 } else {
-                    outputFile.getParentFile().mkdirs();
+                    // 파일 생성
+                    outputFile.getParentFile().mkdirs(); // 필요한 디렉토리 생성
                     try (OutputStream os = new FileOutputStream(outputFile)) {
                         byte[] buffer = new byte[1024];
                         int len;
@@ -259,6 +288,18 @@ public class FileUtils {
                     }
                 }
             }
+        }
+
+        /**
+         * 최상위 디렉토리를 제거한 경로 반환
+         * 예: dir1/sub1/file2.txt -> sub1/file2.txt
+         */
+        private static String removeTopLevelDirectory(String entryName) {
+            int firstSlashIndex = entryName.indexOf('/');
+            if (firstSlashIndex >= 0) {
+                return entryName.substring(firstSlashIndex + 1); // 첫 번째 슬래시 이후 경로 반환
+            }
+            return entryName; // 슬래시가 없으면 그대로 반환
         }
 
     }

--- a/server/src/main/java/org/crichton/util/FileUtils.java
+++ b/server/src/main/java/org/crichton/util/FileUtils.java
@@ -186,8 +186,8 @@ public class FileUtils {
 
         public static void extractFile(MultipartFile file, String destDir) throws IOException {
             // MIME 타입과 확장자 분석
-            String mimeType = getMimeTypeByTika(file);
-            String fileExtension = FileUtils.getMimeTypeByTika(file);
+            String mimeType = FileUtils.getMimeTypeByTika(file);
+            String fileExtension = FilenameUtils.getExtension(file.getOriginalFilename());
 
             UploadAllowFileDefine fileDefine = UploadAllowFileDefine.getByMimeTypeAndExtension(mimeType, fileExtension);
             if (fileDefine == null) {

--- a/server/src/main/java/org/crichton/util/FileUtils.java
+++ b/server/src/main/java/org/crichton/util/FileUtils.java
@@ -2,6 +2,13 @@ package org.crichton.util;
 
 import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import net.lingala.zip4j.ZipFile;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.tika.Tika;
+import org.crichton.domain.utils.enums.UploadAllowFileDefine;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.*;
@@ -169,6 +176,121 @@ public class FileUtils {
     public static void makeDirectory(File directory) {
         if(!directory.exists()) {
             directory.mkdirs();
+        }
+    }
+
+    public static class CompressFile {
+        private CompressFile() {
+            throw new IllegalStateException("Utility class");
+        }
+
+        public static void extractFile(MultipartFile file, String destDir) throws IOException {
+            // MIME 타입과 확장자 분석
+            String mimeType = getMimeTypeByTika(file);
+            String fileExtension = FileUtils.getMimeTypeByTika(file);
+
+            UploadAllowFileDefine fileDefine = UploadAllowFileDefine.getByMimeTypeAndExtension(mimeType, fileExtension);
+            if (fileDefine == null) {
+                throw new IOException("Unsupported file format: MIME=" + mimeType + ", Extension=" + fileExtension);
+            }
+
+            File tempFile = Files.createTempFile("temp", "." + fileExtension).toFile();
+            file.transferTo(tempFile);
+
+            try {
+                switch (fileDefine) {
+                    case ZIP:
+                        unzipFile(tempFile, destDir);
+                        break;
+                    case TAR:
+                        extractTarFile(tempFile, destDir);
+                        break;
+                    case GZ:
+                    case TGZ:
+                    case TAR_GZ:
+                        extractTarGzFile(tempFile, destDir);
+                        break;
+                    default:
+                        throw new IOException("Unsupported extraction method for: " + fileDefine.name());
+                }
+            } finally {
+                tempFile.delete();
+            }
+        }
+
+        public static void unzipFile(File zipFile, String destDir) throws IOException {
+            try (net.lingala.zip4j.ZipFile zip = new net.lingala.zip4j.ZipFile(zipFile)) {
+                zip.extractAll(destDir);
+            }
+        }
+
+        public static void extractTarGzFile(File tarGzFile, String destDir) throws IOException {
+            try (FileInputStream fis = new FileInputStream(tarGzFile);
+                 BufferedInputStream bis = new BufferedInputStream(fis);
+                 GzipCompressorInputStream gis = new GzipCompressorInputStream(bis);
+                 TarArchiveInputStream tis = new TarArchiveInputStream(gis)) {
+
+                extractTarArchive(tis, destDir);
+            }
+        }
+
+        public static void extractTarFile(File tarFile, String destDir) throws IOException {
+            try (FileInputStream fis = new FileInputStream(tarFile);
+                 TarArchiveInputStream tis = new TarArchiveInputStream(fis)) {
+
+                extractTarArchive(tis, destDir);
+            }
+        }
+
+        public static void extractTarArchive(TarArchiveInputStream tis, String destDir) throws IOException {
+            TarArchiveEntry entry;
+            while ((entry = tis.getNextTarEntry()) != null) {
+                File outputFile = new File(destDir, entry.getName());
+                if (entry.isDirectory()) {
+                    outputFile.mkdirs();
+                } else {
+                    outputFile.getParentFile().mkdirs();
+                    try (OutputStream os = new FileOutputStream(outputFile)) {
+                        byte[] buffer = new byte[1024];
+                        int len;
+                        while ((len = tis.read(buffer)) > 0) {
+                            os.write(buffer, 0, len);
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+    /**
+     * apache Tika라이브러리를 이용해서 파일의 mimeType을 가져옴
+     *
+     * @param multipartFile
+     * @return
+     */
+    public static String getMimeTypeByTika(MultipartFile multipartFile) {
+        try(var inputStream = multipartFile.getInputStream()) {
+
+            Tika tika = new Tika();
+
+            // MIME 타입 감지
+            String mimeType = tika.detect(inputStream);
+            log.debug("업로드 요청된 파일 {}의 mimeType:{}", multipartFile.getOriginalFilename(), mimeType);
+
+            // 확장자가 .json이면서 mimeType이 text/plain이거나 application/octet-stream인 경우,
+            // application/json으로 설정
+            String fileExtension = FilenameUtils.getExtension(multipartFile.getOriginalFilename());
+            if ("json".equalsIgnoreCase(fileExtension) &&
+                    ("text/plain".equalsIgnoreCase(mimeType) || "application/octet-stream".equalsIgnoreCase(mimeType))) {
+                mimeType = "application/json";
+            }
+
+            return mimeType;
+
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            return null;
         }
     }
 

--- a/server/src/main/java/org/crichton/util/functional/ValueModifier.java
+++ b/server/src/main/java/org/crichton/util/functional/ValueModifier.java
@@ -1,7 +1,9 @@
 package org.crichton.util.functional;
 
+import java.io.IOException;
+
 // 값 수정 로직을 정의하는 인터페이스
 @FunctionalInterface
 public interface ValueModifier<T> {
-    T modifyValue(T currentValue);
+    T modifyValue(T currentValue) throws IOException;
 }

--- a/server/src/main/resources-dev/logback-spring.xml
+++ b/server/src/main/resources-dev/logback-spring.xml
@@ -11,7 +11,7 @@
 
 
     <!-- 루트 로거 설정 (필수) -->
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="CONSOLE" />
     </root>
 

--- a/server/src/test/java/org/crichton/mapper/UploadFileTest.java
+++ b/server/src/test/java/org/crichton/mapper/UploadFileTest.java
@@ -5,7 +5,6 @@ import org.crichton.domain.utils.mapper.ProjectInformationMapper;
 import org.crichton.util.constants.DirectoryName;
 import org.crichton.util.constants.FileName;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,7 +17,6 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -37,7 +35,7 @@ public class UploadFileTest {
     // 테스트 디렉토리 경로
     private Path testDirectory;
 
-    @Test
+//    @Test
     void processAndSplitTestSpecFiles_shouldProcessResourceFile() throws Exception {
         // Arrange
         String basePath = "crichton/data";

--- a/server/src/test/java/org/crichton/mapper/UploadFileTest.java
+++ b/server/src/test/java/org/crichton/mapper/UploadFileTest.java
@@ -1,0 +1,89 @@
+package org.crichton.mapper;
+
+import org.crichton.configuration.CrichtonDataStorageProperties;
+import org.crichton.domain.utils.mapper.ProjectInformationMapper;
+import org.crichton.util.constants.DirectoryName;
+import org.crichton.util.constants.FileName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@EnableConfigurationProperties(CrichtonDataStorageProperties.class)
+@TestPropertySource(locations = "classpath:application.properties")
+public class UploadFileTest {
+
+    @Autowired
+    private ProjectInformationMapper projectInformationMapper;
+
+    @MockBean
+    private CrichtonDataStorageProperties crichtonDataStorageProperties;
+
+    // 테스트 디렉토리 경로
+    private Path testDirectory;
+
+    @Test
+    void processAndSplitTestSpecFiles_shouldProcessResourceFile() throws Exception {
+        // Arrange
+        String basePath = "crichton/data";
+        testDirectory = Path.of(basePath, "test");
+        Files.createDirectories(testDirectory.resolve(DirectoryName.INJECT_TEST));
+        copyResourceFileToTestDirectory("testSpecFile.json", testDirectory.resolve(DirectoryName.INJECT_TEST).resolve(FileName.TEST_SPEC).toString());
+
+        // Use Reflection to access private method
+        Method method = ProjectInformationMapper.class.getDeclaredMethod("processAndSplitTestSpecFiles", Path.class);
+        method.setAccessible(true);
+
+        // Act
+        method.invoke(projectInformationMapper, testDirectory);
+
+        // Assert
+        File defectFile = testDirectory.resolve(DirectoryName.INJECT_TEST).resolve(FileName.DEFECT_SPEC).toFile();
+        assertThat(defectFile).exists();
+
+
+        method = ProjectInformationMapper.class.getDeclaredMethod("replaceTestSpecTaskFilePath", Path.class);
+        method.setAccessible(true);
+
+        // Act
+        method.invoke(projectInformationMapper, testDirectory.toAbsolutePath());
+
+        // Optionally check file content
+        // assertThat(defectFile).hasContent("{expected_json_content}");
+    }
+
+    private void copyResourceFileToTestDirectory(String resourceName, String targetPath) throws Exception {
+        try (InputStream resourceStream = getClass().getResourceAsStream("/" + resourceName)) {
+            if (resourceStream == null) {
+                throw new IllegalArgumentException("Resource not found: " + resourceName);
+            }
+            Files.copy(resourceStream, Path.of(targetPath), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        if (testDirectory != null && Files.exists(testDirectory)) {
+            Files.walk(testDirectory)
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+
+            Files.deleteIfExists(testDirectory);
+        }
+    }
+}

--- a/server/src/test/resources/testSpecFile.json
+++ b/server/src/test/resources/testSpecFile.json
@@ -1,0 +1,111 @@
+{
+  "defects":
+  [
+    {
+      "id": 3,
+      "trigger": 500,
+      "cycle": 100000,
+      "target": "bmsp_sys_arch.c",
+      "name": "memory_fault",
+      "defect": [
+        {
+          "kind": "taint",
+          "var": "bmsp_sys_arch_P.Constant2_Value",
+          "type": "int",
+          "value": "0",
+          "pattern": "constant"
+        }
+      ],
+      "build": "build1"
+    },
+
+    {
+      "id": 5,
+      "trigger": 500,
+      "cycle": 100000,
+      "target": "bmsp_sys_arch.c",
+      "name": "interface_fault",
+      "defect": [
+        {
+          "kind": "taint",
+          "var": "bmsp_sys_arch_P.Constant6_Value",
+          "type": "int",
+          "value": "40000",
+          "pattern": "constant"
+        },
+        {
+          "kind": "taint",
+          "var": "bmsp_sys_arch_P.Constant2_Value",
+          "type": "int",
+          "value": "0",
+          "pattern": "constant"
+        }
+      ],
+      "build": "build2"
+    }
+  ],
+
+
+  "builds":
+  {
+    "build2": {
+      "tasks": [
+        {
+          "name": "pre_init",
+          "start": 0,
+          "cycle": 1000,
+          "priority": 10,
+          "file": "presetup.c"
+        },
+        {
+          "name": "bmsp_sys_arch_step",
+          "start": 100,
+          "cycle": 100,
+          "priority": 10,
+          "file": "bmsp_sys_arch.c"
+        }
+
+      ],
+
+      "extra_srcs": [
+        "bmsp_sys_arch_data.c",
+        "rtGetInf.c",
+        "rtGetNaN.c",
+        "rt_nonfinite.c"
+      ],
+
+      "stop": 1000
+    },
+
+    "build1":
+    {
+      "tasks": [
+        {
+          "name": "pre_init",
+          "start": 0,
+          "cycle": 1000,
+          "priority": 10,
+          "file": "presetup.c"
+        },
+        {
+          "name": "bmsp_sys_arch_step",
+          "start": 100,
+          "cycle": 100,
+          "priority": 10,
+          "file": "bmsp_sys_arch.c"
+        }
+
+      ],
+
+      "extra_srcs": [
+        "bmsp_sys_arch_data.c",
+        "rtGetInf.c",
+        "rtGetNaN.c",
+        "rt_nonfinite.c"
+      ],
+
+      "stop": 1000
+    }
+
+  }
+}


### PR DESCRIPTION
### ADD
- `테스트 명세` JSON 파일과 `결함 주입 명세` JSON 파일을 통합된 JSON 파일로 변경
  - `builds`: 
    - 기존 `test_spec.json` 파일로 하나의 task 케이스 집합만 보냈으나 다양한 케이스를 보내기 위한 `test_spec.json` 내용의 집합
  - `defects`
    - 기존 defect_spec.json의 내용
    - `build` 키를 통해 분석 대상으로 지정한 `test_spec.json` 파일 선택
     - json 파일이름이 아닌 builds 내의 키 이름으로 지정할 것

- 통합된 JSON 파일에서 `defect_spec.json` 파일을 추출하는 기능 추가
- 통합된 JSON 파일에서 `테스트 명세` JSON 파일` 들을 추출하는 기능 추가
- 플러그인에서 `defect_spec.json`에 통해 분석 대상에 해당되는 `테스트 명세` JSON 파일 선택하도록 기능 추가

### FIX
- `tar`, `tar.gz` 와 같은 소스코드를 아카이브로 압축한 파일을 해제 못하는 버그 수정