### PR TITLE
[fix] 결함 주입 테스트 실패 버그 수정

### DIFF
--- a/plugins/runner/src/main/java/runner/util/constants/DirectoryName.java
+++ b/plugins/runner/src/main/java/runner/util/constants/DirectoryName.java
@@ -1,0 +1,9 @@
+package runner.util.constants;
+
+public class DirectoryName {
+    public static final String SOURCE = "src";
+    public static final String INJECT_TEST = "inject-test";
+    public static final String UNIT_TEST = "unit-test";
+    public static final String DEFECT_SIMULATION = "defectSim";
+    public static final String DEFECT_BUILD = "build";
+}


### PR DESCRIPTION
- 여러 결함 스펙에 대해 하나의 프로젝트에서 처리시 결함 분석이 실패하는 현상이 발생
- 결함 주입 테스트 파일을 생성하는 모듈이 기존에 사용한 파일이 남아 있으면 파일을 덮어 쓰지 않고 생성을 스킵
- 이전 결함 테스트시 생성된 파일을 통해 테스트 주입용 실행 파일을 생성하려고 하니 컴파일 에러가 발생하는 현상을 발견
- 여러 결함 주입 테스트 명세가 작성된 JSON 파일이 왔을때 plugin에서 결함 주입 테스트가 끝날때 마다 생성 되었던 파일 및 디렉토리들을 삭제하도록 로직수정