### PR TITLE
[feature] 결함 주입 테스트시 사용 하는 플래그 추가

### DIFF
--- a/engines/CrichtonDefectInjector/DefectInjector/Program.fs
+++ b/engines/CrichtonDefectInjector/DefectInjector/Program.fs
@@ -178,12 +178,20 @@ let modifiedFile
     swOil.Write(oilContents)
 
 let mutable CFLAGS = "-ggdb -DPOSIX"
+let mutable LDFLAGS = ""
 let mutable trampolinePath = "../../.."
 
 
 let genOILCode (tasks: TestLib.TestDef) =
     let mutable userCode = ""
     let mutable cnt  = 1
+    
+    if tasks.CFLAGS.IsSome then
+        CFLAGS <- $"{CFLAGS} {tasks.CFLAGS.Value}"
+        
+    if tasks.LDFLAGS.IsSome then
+        LDFLAGS <- $"{LDFLAGS} {tasks.LDFLAGS.Value}"
+    
     for task in tasks.Tasks do
         let alarmDef = (sprintf """
   ALARM crichton_alarm_%d {
@@ -254,6 +262,7 @@ CPU only_one_periodic_task {
       TRAMPOLINE_BASE_PATH = "%s";
       APP_NAME = "defectSim_exe";
       CFLAGS="%s";
+      LDFLAGS="%s";
       LINKER = "gcc";
       SYSTEM = PYTHON;
     };
@@ -261,7 +270,7 @@ CPU only_one_periodic_task {
     APPMODE stdAppmode {};
     %s
     };
-""" app_srcs trampolinePath CFLAGS userCode)
+""" app_srcs trampolinePath CFLAGS LDFLAGS userCode)
     str
 
 let genSrcCode (tasks: TestLib.TestDef) =

--- a/engines/CrichtonDefectInjector/InjectionTester/Program.fs
+++ b/engines/CrichtonDefectInjector/InjectionTester/Program.fs
@@ -87,6 +87,7 @@ let parseLog (log: string) =
    
 
 let monitor (execFile: string, args) =
+    printfn $">>> {execFile} {args}"
     let processInfo = new ProcessStartInfo(execFile, args)
     let mutable otherText = ""
     let mutable printText = ""

--- a/engines/CrichtonDefectInjector/SpecLib/SpecLib.fs
+++ b/engines/CrichtonDefectInjector/SpecLib/SpecLib.fs
@@ -26,6 +26,8 @@ module TestLib =
         Tasks: TaskDef list
         Stop: int
         ExtraSrcs: string list
+        CFLAGS: string option
+        LDFLAGS: string option
     }
     
     let testParser (obj: JObject):TestDef =
@@ -48,7 +50,20 @@ module TestLib =
                      |> Seq.toList
 
         let stop = root["stop"].ToObject<int>()
-        { Tasks = tasks; Stop = stop; ExtraSrcs = extras }
+        
+        let cflags =
+            if isNull root["cflags"] then
+                None
+            else
+                Some <| root["cflags"].ToObject<string>()
+        
+        let ldflags =
+            if isNull root["ldflags"] then
+                None
+            else
+                Some <| root["ldflags"].ToObject<string>()
+        
+        { Tasks = tasks; Stop = stop; ExtraSrcs = extras; CFLAGS = cflags; LDFLAGS = ldflags }
         
 module DefectLib =
     type DefectType =


### PR DESCRIPTION
## 문제사항
- 결함 주입 테스트시 분석을 위해 엔진에서 대상 소스코드 빌드시 cflags와 ldflags 옵션 사용하는 case 발견

## 변경 사항

### SpectLib/SpecLib.fs
- test spec 명세 JSON 파일에 입력시 결함 주입 테스트에서 cflags와 ldflags 옵션 플래그를 사용 하도록 파서 추가

### DefectInjector/Program.fs
- 결함 주입 테스트를 위한 바이너리 파일 생성시 cflags와 ldflags를 사용하는 경우 해당 옵션을 사용하여 바이너리 파일 생성하도록 수정

### InjectionTester/Program.fs
- 로그상에서 실행하는 명령어 확인을 위한 출력문 작성